### PR TITLE
Rm const generics

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Implementations from scratch done while studying some FHE papers; do not use in 
 
 This example shows usage of TFHE, but the idea is that the same interface would
 work for using CKKS & BFV, the only thing to be changed would be the parameters
-and the line `type S = TWLE<K>` to use `CKKS<Q, N>` or `BFV<Q, N, T>`.
+and the usage of `TLWE` by `CKKS` or `BFV`.
 
 ```rust
 let param = Param {
@@ -31,7 +31,7 @@ let msg_dist = Uniform::new(0_u64, param.t);
 
 let (sk, pk) = TLWE::new_key(&mut rng, &param)?;
 
-// get two random msgs in Z_t
+// get three random msgs in Rt
 let m1 = Rq::rand_u64(&mut rng, msg_dist, &param.pt())?;
 let m2 = Rq::rand_u64(&mut rng, msg_dist, &param.pt())?;
 let m3 = Rq::rand_u64(&mut rng, msg_dist, &param.pt())?;
@@ -39,8 +39,9 @@ let m3 = Rq::rand_u64(&mut rng, msg_dist, &param.pt())?;
 // encode the msgs into the plaintext space
 let p1 = TLWE::encode(&param, &m1); // plaintext
 let p2 = TLWE::encode(&param, &m2); // plaintext
-let c3_const: T64 = T64(m3.coeffs()[0].v); // encode it as constant
+let c3_const = TLWE::new_const(&param, &m3); // as constant/public value
 
+// encrypt p1 and m2
 let c1 = TLWE::encrypt(&mut rng, &param, &pk, &p1)?;
 let c2 = TLWE::encrypt(&mut rng, &param, &pk, &p2)?;
 

--- a/README.md
+++ b/README.md
@@ -19,27 +19,30 @@ work for using CKKS & BFV, the only thing to be changed would be the parameters
 and the line `type S = TWLE<K>` to use `CKKS<Q, N>` or `BFV<Q, N, T>`.
 
 ```rust
-const T: u64 = 128; // msg space (msg modulus)
-type M = Rq<T, 1>; // msg space
-type S = TLWE<256>;
+let param = Param {
+    err_sigma: crate::ERR_SIGMA,
+    ring: RingParam { q: u64::MAX, n: 1 },
+    k: 256,
+    t: 128, // plaintext modulus
+};
 
 let mut rng = rand::thread_rng();
-let msg_dist = Uniform::new(0_u64, T);
+let msg_dist = Uniform::new(0_u64, param.t);
 
-let (sk, pk) = S::new_key(&mut rng)?;
+let (sk, pk) = TLWE::new_key(&mut rng, &param)?;
 
 // get two random msgs in Z_t
-let m1 = M::rand_u64(&mut rng, msg_dist)?;
-let m2 = M::rand_u64(&mut rng, msg_dist)?;
-let m3 = M::rand_u64(&mut rng, msg_dist)?;
+let m1 = Rq::rand_u64(&mut rng, msg_dist, &param.pt())?;
+let m2 = Rq::rand_u64(&mut rng, msg_dist, &param.pt())?;
+let m3 = Rq::rand_u64(&mut rng, msg_dist, &param.pt())?;
 
 // encode the msgs into the plaintext space
-let p1 = S::encode::<T>(&m1); // plaintext
-let p2 = S::encode::<T>(&m2); // plaintext
-let c3_const: Tn<1> = Tn(array::from_fn(|i| T64(m3.coeffs()[i].0))); // encode it as constant
+let p1 = TLWE::encode(&param, &m1); // plaintext
+let p2 = TLWE::encode(&param, &m2); // plaintext
+let c3_const: T64 = T64(m3.coeffs()[0].v); // encode it as constant
 
-let c1 = S::encrypt(&mut rng, &pk, &p1)?;
-let c2 = S::encrypt(&mut rng, &pk, &p2)?;
+let c1 = TLWE::encrypt(&mut rng, &param, &pk, &p1)?;
+let c2 = TLWE::encrypt(&mut rng, &param, &pk, &p2)?;
 
 // now we can do encrypted operations (notice that we do them using simple
 // operation notation by rust's operator overloading):
@@ -48,9 +51,10 @@ let c4 = c_12 * c3_const;
 
 // decrypt & decode
 let p4_recovered = c4.decrypt(&sk);
-let m4 = S::decode::<T>(&p4_recovered);
+let m4 = TLWE::decode(&param, &p4_recovered);
 
 // m4 is equal to (m1+m2)*m3
+assert_eq!(((m1 + m2).to_r() * m3.to_r()).to_rq(param.t), m4);
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ let m4 = S::decode::<T>(&p4_recovered);
 	- external products of ciphertexts
 		- TGSW x TLWE
 		- TGGSW x TGLWE
-	- TGSW & TGGSW CMux gate
+	- {TGSW, TGGSW} CMux gate
 	- blind rotation, key switching, mod switching
 	- bootstrapping
 - CKKS

--- a/arith/Cargo.toml
+++ b/arith/Cargo.toml
@@ -8,6 +8,7 @@ anyhow = { workspace = true }
 rand = { workspace = true }
 rand_distr = { workspace = true }
 itertools = { workspace = true }
+lazy_static = "1.5.0"
 
 # TMP: the next 4 imports are TMP, to solve systems of linear equations. Used
 # for the CKKS encoding step, probably remvoed once in ckks the encoding is done

--- a/arith/src/lib.rs
+++ b/arith/src/lib.rs
@@ -6,29 +6,29 @@
 
 pub mod complex;
 pub mod matrix;
-pub mod torus;
+// pub mod torus;
 pub mod zq;
 
 pub mod ring;
 pub mod ring_n;
 pub mod ring_nq;
-pub mod ring_torus;
-pub mod tuple_ring;
+// pub mod ring_torus;
+// pub mod tuple_ring;
 
-mod naive_ntt; // note: for dev only
+// mod naive_ntt; // note: for dev only
 pub mod ntt;
 
 // expose objects
 
 pub use complex::C;
 pub use matrix::Matrix;
-pub use torus::T64;
+// pub use torus::T64;
 pub use zq::Zq;
 
 pub use ring::Ring;
 pub use ring_n::R;
 pub use ring_nq::Rq;
-pub use ring_torus::Tn;
-pub use tuple_ring::TR;
+// pub use ring_torus::Tn;
+// pub use tuple_ring::TR;
 
 pub use ntt::NTT;

--- a/arith/src/lib.rs
+++ b/arith/src/lib.rs
@@ -25,7 +25,7 @@ pub use matrix::Matrix;
 // pub use torus::T64;
 pub use zq::Zq;
 
-pub use ring::Ring;
+pub use ring::{Ring, RingParam};
 pub use ring_n::R;
 pub use ring_nq::Rq;
 // pub use ring_torus::Tn;

--- a/arith/src/lib.rs
+++ b/arith/src/lib.rs
@@ -6,14 +6,14 @@
 
 pub mod complex;
 pub mod matrix;
-// pub mod torus;
+pub mod torus;
 pub mod zq;
 
 pub mod ring;
 pub mod ring_n;
 pub mod ring_nq;
-// pub mod ring_torus;
-// pub mod tuple_ring;
+pub mod ring_torus;
+pub mod tuple_ring;
 
 // mod naive_ntt; // note: for dev only
 pub mod ntt;
@@ -22,13 +22,13 @@ pub mod ntt;
 
 pub use complex::C;
 pub use matrix::Matrix;
-// pub use torus::T64;
+pub use torus::T64;
 pub use zq::Zq;
 
 pub use ring::{Ring, RingParam};
 pub use ring_n::R;
 pub use ring_nq::Rq;
-// pub use ring_torus::Tn;
-// pub use tuple_ring::TR;
+pub use ring_torus::Tn;
+pub use tuple_ring::TR;
 
 pub use ntt::NTT;

--- a/arith/src/lib.rs
+++ b/arith/src/lib.rs
@@ -19,7 +19,6 @@ pub mod tuple_ring;
 pub mod ntt;
 
 // expose objects
-
 pub use complex::C;
 pub use matrix::Matrix;
 pub use torus::T64;

--- a/arith/src/ntt.rs
+++ b/arith/src/ntt.rs
@@ -241,4 +241,27 @@ mod tests {
         }
         Ok(())
     }
+
+    // #[test]
+    // fn test_ntt_loop_2() -> Result<()> {
+    //     // let q: u64 = 2u64.pow(16) + 1;
+    //     // let n: usize = 512;
+    //     let q: u64 = 35184371138561;
+    //     let n: usize = 1 << 14;
+    //     let param = RingParam { q, n };
+    //
+    //     use rand::distributions::Uniform;
+    //     let mut rng = rand::thread_rng();
+    //     let dist = Uniform::new(0_f64, q as f64);
+    //
+    //     let a: Rq = Rq::rand(&mut rng, dist, &param);
+    //     let start = std::time::Instant::now();
+    //     for _ in 0..10_000 {
+    //         let a_ntt = NTT::ntt(&a);
+    //         let a_intt = NTT::intt(&a_ntt);
+    //         assert_eq!(a, a_intt);
+    //     }
+    //     dbg!(start.elapsed());
+    //     Ok(())
+    // }
 }

--- a/arith/src/ntt.rs
+++ b/arith/src/ntt.rs
@@ -6,11 +6,7 @@
 //! generics; but once using real-world parameters, the stack could not handle
 //! it, so moved to use Vec instead of fixed-sized arrays, and adapted the NTT
 //! implementation to that too.
-use crate::{
-    ring::{Ring, RingParam},
-    ring_nq::Rq,
-    zq::Zq,
-};
+use crate::{ring::RingParam, ring_nq::Rq, zq::Zq};
 
 use std::collections::HashMap;
 
@@ -197,6 +193,7 @@ const fn const_inv_mod(q: u64, x: u64) -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::Ring;
 
     use anyhow::Result;
 

--- a/arith/src/ntt_fixedsize.rs
+++ b/arith/src/ntt_fixedsize.rs
@@ -1,0 +1,187 @@
+//! Implementation of the NTT & iNTT, following the CT & GS algorighms, more details in
+//! https://eprint.iacr.org/2017/727.pdf, some notes at
+//! https://github.com/arnaucube/math/blob/master/notes_ntt.pdf .
+use crate::zq::Zq;
+
+#[derive(Debug)]
+pub struct NTT<const Q: u64, const N: usize> {}
+
+impl<const Q: u64, const N: usize> NTT<Q, N> {
+    const N_INV: Zq<Q> = Zq(const_inv_mod::<Q>(N as u64));
+    // since we work over Zq[X]/(X^N+1) (negacyclic), get the 2*N-th root of unity
+    pub(crate) const ROOT_OF_UNITY: u64 = primitive_root_of_unity::<Q>(2 * N);
+    pub(crate) const ROOTS_OF_UNITY: [Zq<Q>; N] = roots_of_unity(Self::ROOT_OF_UNITY);
+    const ROOTS_OF_UNITY_INV: [Zq<Q>; N] = roots_of_unity_inv(Self::ROOTS_OF_UNITY);
+}
+
+impl<const Q: u64, const N: usize> NTT<Q, N> {
+    /// implements the Cooley-Tukey (CT) algorithm. Details at
+    /// https://eprint.iacr.org/2017/727.pdf, also some notes at section 3.1 of
+    /// https://github.com/arnaucube/math/blob/master/notes_ntt.pdf
+    pub fn ntt(a: [Zq<Q>; N]) -> [Zq<Q>; N] {
+        let mut t = N / 2;
+        let mut m = 1;
+        let mut r: [Zq<Q>; N] = a.clone();
+        while m < N {
+            let mut k = 0;
+            for i in 0..m {
+                let S: Zq<Q> = Self::ROOTS_OF_UNITY[m + i];
+                for j in k..k + t {
+                    let U: Zq<Q> = r[j];
+                    let V: Zq<Q> = r[j + t] * S;
+                    r[j] = U + V;
+                    r[j + t] = U - V;
+                }
+                k = k + 2 * t;
+            }
+            t /= 2;
+            m *= 2;
+        }
+        r
+    }
+
+    /// implements the Cooley-Tukey (CT) algorithm. Details at
+    /// https://eprint.iacr.org/2017/727.pdf, also some notes at section 3.2 of
+    /// https://github.com/arnaucube/math/blob/master/notes_ntt.pdf
+    pub fn intt(a: [Zq<Q>; N]) -> [Zq<Q>; N] {
+        let mut t = 1;
+        let mut m = N / 2;
+        let mut r: [Zq<Q>; N] = a.clone();
+        while m > 0 {
+            let mut k = 0;
+            for i in 0..m {
+                let S: Zq<Q> = Self::ROOTS_OF_UNITY_INV[m + i];
+                for j in k..k + t {
+                    let U: Zq<Q> = r[j];
+                    let V: Zq<Q> = r[j + t];
+                    r[j] = U + V;
+                    r[j + t] = (U - V) * S;
+                }
+                k += 2 * t;
+            }
+            t *= 2;
+            m /= 2;
+        }
+        for i in 0..N {
+            r[i] = r[i] * Self::N_INV;
+        }
+        r
+    }
+}
+
+/// computes a primitive N-th root of unity using the method described by Thomas
+/// Pornin in https://crypto.stackexchange.com/a/63616
+const fn primitive_root_of_unity<const Q: u64>(N: usize) -> u64 {
+    assert!(N.is_power_of_two());
+    assert!((Q - 1) % N as u64 == 0);
+
+    let n: u64 = N as u64;
+    let mut k = 1;
+    while k < Q {
+        // alternatively could get a random k at each iteration, if so, add the following if:
+        // `if k == 0 { continue; }`
+        let w = const_exp_mod::<Q>(k, (Q - 1) / n);
+        if const_exp_mod::<Q>(w, n / 2) != 1 {
+            return w; // w is a primitive N-th root of unity
+        }
+        k += 1;
+    }
+    panic!("No primitive root of unity");
+}
+
+const fn roots_of_unity<const Q: u64, const N: usize>(w: u64) -> [Zq<Q>; N] {
+    let mut r: [Zq<Q>; N] = [Zq(0u64); N];
+    let mut i = 0;
+    let log_n = N.ilog2();
+    while i < N {
+        // (return the roots in bit-reverset order)
+        let j = ((i as u64).reverse_bits() >> (64 - log_n)) as usize;
+        r[i] = Zq(const_exp_mod::<Q>(w, j as u64));
+        i += 1;
+    }
+    r
+}
+
+const fn roots_of_unity_inv<const Q: u64, const N: usize>(v: [Zq<Q>; N]) -> [Zq<Q>; N] {
+    // assumes that the inputted roots are already in bit-reverset order
+    let mut r: [Zq<Q>; N] = [Zq(0u64); N];
+    let mut i = 0;
+    while i < N {
+        r[i] = Zq(const_inv_mod::<Q>(v[i].0));
+        i += 1;
+    }
+    r
+}
+
+/// returns x^k mod Q
+const fn const_exp_mod<const Q: u64>(x: u64, k: u64) -> u64 {
+    // work on u128 to avoid overflow
+    let mut r = 1u128;
+    let mut x = x as u128;
+    let mut k = k as u128;
+    x = x % Q as u128;
+    // exponentiation by square strategy
+    while k > 0 {
+        if k % 2 == 1 {
+            r = (r * x) % Q as u128;
+        }
+        x = (x * x) % Q as u128;
+        k /= 2;
+    }
+    r as u64
+}
+
+/// returns x^-1 mod Q
+const fn const_inv_mod<const Q: u64>(x: u64) -> u64 {
+    // by Fermat's Little Theorem, x^-1 mod q \equiv  x^{q-2} mod q
+    const_exp_mod::<Q>(x, Q - 2)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use anyhow::Result;
+    use std::array;
+
+    #[test]
+    fn test_ntt() -> Result<()> {
+        const Q: u64 = 2u64.pow(16) + 1;
+        const N: usize = 4;
+
+        let a: [u64; N] = [1u64, 2, 3, 4];
+        let a: [Zq<Q>; N] = array::from_fn(|i| Zq::from_u64(a[i]));
+
+        let a_ntt = NTT::<Q, N>::ntt(a);
+
+        let a_intt = NTT::<Q, N>::intt(a_ntt);
+
+        dbg!(&a);
+        dbg!(&a_ntt);
+        dbg!(&a_intt);
+        dbg!(NTT::<Q, N>::ROOT_OF_UNITY);
+        dbg!(NTT::<Q, N>::ROOTS_OF_UNITY);
+
+        assert_eq!(a, a_intt);
+        Ok(())
+    }
+
+    #[test]
+    fn test_ntt_loop() -> Result<()> {
+        const Q: u64 = 2u64.pow(16) + 1;
+        const N: usize = 512;
+
+        use rand::distributions::Distribution;
+        use rand::distributions::Uniform;
+        let mut rng = rand::thread_rng();
+        let dist = Uniform::new(0_f64, Q as f64);
+
+        for _ in 0..100 {
+            let a: [Zq<Q>; N] = array::from_fn(|_| Zq::from_f64(dist.sample(&mut rng)));
+            let a_ntt = NTT::<Q, N>::ntt(a);
+            let a_intt = NTT::<Q, N>::intt(a_ntt);
+            assert_eq!(a, a_intt);
+        }
+        Ok(())
+    }
+}

--- a/arith/src/ring.rs
+++ b/arith/src/ring.rs
@@ -21,27 +21,28 @@ pub trait Ring:
     + PartialEq
     + Debug
     + Clone
-    + Copy
+    // + Copy
     + Sum<<Self as Add>::Output>
     + Sum<<Self as Mul>::Output>
 {
     /// C defines the coefficient type
     type C: Debug + Clone;
+    type Params: Debug+Clone+Copy;
 
-    const Q: u64;
-    const N: usize;
+    // const Q: u64;
+    // const N: usize;
 
     fn coeffs(&self) -> Vec<Self::C>;
-    fn zero() -> Self;
+    fn zero(params: Self::Params) -> Self;
     // note/wip/warning: dist (0,q) with f64, will output more '0=q' elements than other values
-    fn rand(rng: impl Rng, dist: impl Distribution<f64>) -> Self;
+    fn rand(rng: impl Rng, dist: impl Distribution<f64>, params: Self::Params) -> Self;
 
-    fn from_vec(coeffs: Vec<Self::C>) -> Self;
+    fn from_vec(params: Self::Params, coeffs: Vec<Self::C>) -> Self;
 
     fn decompose(&self, beta: u32, l: u32) -> Vec<Self>;
 
-    fn remodule<const P: u64>(&self) -> impl Ring;
-    fn mod_switch<const P: u64>(&self) -> impl Ring;
+    fn remodule(&self, p:u64) -> impl Ring;
+    fn mod_switch(&self, p:u64) -> impl Ring;
 
     /// returns [ [(num/den) * self].round() ] mod q
     /// ie. performs the multiplication and division over f64, and then it

--- a/arith/src/ring.rs
+++ b/arith/src/ring.rs
@@ -33,10 +33,6 @@ pub trait Ring:
 {
     /// C defines the coefficient type
     type C: Debug + Clone;
-    // type Param: Debug+Clone+Copy;
-
-    // const Q: u64;
-    // const N: usize;
 
     fn param(&self) -> RingParam;
     fn coeffs(&self) -> Vec<Self::C>;

--- a/arith/src/ring.rs
+++ b/arith/src/ring.rs
@@ -3,6 +3,12 @@ use std::fmt::Debug;
 use std::iter::Sum;
 use std::ops::{Add, AddAssign, Mul, Neg, Sub, SubAssign};
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct RingParam {
+    pub q: u64, // TODO think if really needed or it's fine with coeffs[0].q
+    pub n: usize,
+}
+
 /// Represents a ring element. Currently implemented by ring_nq.rs#Rq and
 /// ring_torus.rs#Tn. Is not a 'pure algebraic ring', but more a custom trait
 /// definition which includes methods like `mod_switch`.
@@ -27,17 +33,18 @@ pub trait Ring:
 {
     /// C defines the coefficient type
     type C: Debug + Clone;
-    type Params: Debug+Clone+Copy;
+    // type Param: Debug+Clone+Copy;
 
     // const Q: u64;
     // const N: usize;
 
+    fn param(&self) -> RingParam;
     fn coeffs(&self) -> Vec<Self::C>;
-    fn zero(params: Self::Params) -> Self;
+    fn zero(param: &RingParam) -> Self;
     // note/wip/warning: dist (0,q) with f64, will output more '0=q' elements than other values
-    fn rand(rng: impl Rng, dist: impl Distribution<f64>, params: Self::Params) -> Self;
+    fn rand(rng: impl Rng, dist: impl Distribution<f64>, param: &RingParam) -> Self;
 
-    fn from_vec(params: Self::Params, coeffs: Vec<Self::C>) -> Self;
+    fn from_vec(param: &RingParam, coeffs: Vec<Self::C>) -> Self;
 
     fn decompose(&self, beta: u32, l: u32) -> Vec<Self>;
 

--- a/arith/src/ring_n.rs
+++ b/arith/src/ring_n.rs
@@ -23,7 +23,7 @@ pub struct R {
 // impl<const N: usize> Ring for R<N> {
 impl R {
     // type C = i64;
-    // type Params = usize; // n
+    // type Param = usize; // n
 
     // const Q: u64 = i64::MAX as u64; // WIP
     // const N: usize = N;
@@ -87,7 +87,10 @@ impl R {
 
 impl From<crate::ring_nq::Rq> for R {
     fn from(rq: crate::ring_nq::Rq) -> Self {
-        Self::from_vec_u64(rq.n, rq.coeffs().to_vec().iter().map(|e| e.v).collect())
+        Self::from_vec_u64(
+            rq.param.n,
+            rq.coeffs().to_vec().iter().map(|e| e.v).collect(),
+        )
     }
 }
 
@@ -150,7 +153,7 @@ pub fn mul_div_round(q: u64, n: usize, v: Vec<i64>, num: u64, den: u64) -> crate
         .map(|e| ((num as f64 * *e as f64) / den as f64).round())
         .collect();
     // dbg!(&r);
-    crate::Rq::from_vec_f64(q, n, r)
+    crate::Rq::from_vec_f64(&crate::ring::RingParam { q, n }, r)
 }
 
 // TODO rename to make it clear that is not mod q, but mod X^N+1

--- a/arith/src/ring_n.rs
+++ b/arith/src/ring_n.rs
@@ -15,14 +15,7 @@ pub struct R {
     pub coeffs: Vec<i64>,
 }
 
-// impl<const N: usize> Ring for R<N> {
 impl R {
-    // type C = i64;
-    // type Param = usize; // n
-
-    // const Q: u64 = i64::MAX as u64; // WIP
-    // const N: usize = N;
-
     pub fn coeffs(&self) -> Vec<i64> {
         self.coeffs.clone()
     }
@@ -33,16 +26,12 @@ impl R {
         }
     }
     fn rand(mut rng: impl Rng, dist: impl Distribution<f64>, n: usize) -> Self {
-        // let coeffs: [i64; N] = array::from_fn(|_| Self::C::rand(&mut rng, &dist));
-        // let coeffs: [i64; N] = array::from_fn(|_| dist.sample(&mut rng).round() as i64);
         Self {
             n,
             coeffs: std::iter::repeat_with(|| dist.sample(&mut rng).round() as i64)
                 .take(n)
                 .collect(),
         }
-        // let coeffs: [C; N] = array::from_fn(|_| Zq::from_u64(dist.sample(&mut rng)));
-        // Self(coeffs)
     }
 
     pub fn from_vec(n: usize, coeffs: Vec<i64>) -> Self {
@@ -90,9 +79,6 @@ impl From<crate::ring_nq::Rq> for R {
 }
 
 impl R {
-    // pub fn coeffs(&self) -> [i64; N] {
-    //     self.0
-    // }
     pub fn to_rq(self, q: u64) -> crate::Rq {
         crate::Rq::from((q, self))
     }
@@ -196,7 +182,6 @@ impl Add<&R> for &R {
     type Output = R;
 
     fn add(self, rhs: &R) -> Self::Output {
-        // R(array::from_fn(|i| self.0[i] + rhs.0[i]))
         assert_eq!(self.n, rhs.n);
         R {
             n: self.n,
@@ -220,11 +205,6 @@ impl Sum<R> for R {
     where
         I: Iterator<Item = Self>,
     {
-        // let mut acc = R::zero();
-        // for e in iter {
-        //     acc += e;
-        // }
-        // acc
         let first = iter.next().unwrap();
         iter.fold(first, |acc, x| acc + x)
     }
@@ -234,7 +214,6 @@ impl Sub<R> for R {
     type Output = Self;
 
     fn sub(self, rhs: Self) -> Self {
-        // Self(array::from_fn(|i| self.0[i] - rhs.0[i]))
         assert_eq!(self.n, rhs.n);
         Self {
             n: self.n,
@@ -248,7 +227,6 @@ impl Sub<&R> for &R {
     type Output = R;
 
     fn sub(self, rhs: &R) -> Self::Output {
-        // R(array::from_fn(|i| self.0[i] - rhs.0[i]))
         assert_eq!(self.n, rhs.n);
         R {
             n: self.n,

--- a/arith/src/ring_n.rs
+++ b/arith/src/ring_n.rs
@@ -1,16 +1,11 @@
 //! Polynomial ring Z[X]/(X^N+1)
 //!
 
-use anyhow::Result;
 use itertools::zip_eq;
 use rand::{distributions::Distribution, Rng};
-use std::array;
-use std::borrow::Borrow;
 use std::fmt;
 use std::iter::Sum;
-use std::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
-
-use crate::Ring;
+use std::ops::{Add, AddAssign, Mul, Neg, Sub, SubAssign};
 
 // TODO rename to not have name conflicts with the Ring trait (R: Ring)
 // PolynomialRing element, where the PolynomialRing is R = Z[X]/(X^n +1)

--- a/arith/src/ring_nq.rs
+++ b/arith/src/ring_nq.rs
@@ -4,8 +4,6 @@
 use anyhow::{anyhow, Result};
 use itertools::zip_eq;
 use rand::{distributions::Distribution, Rng};
-use std::array;
-use std::borrow::Borrow;
 use std::fmt;
 use std::iter::Sum;
 use std::ops::{Add, AddAssign, Mul, Neg, Sub, SubAssign};

--- a/arith/src/ring_nq.rs
+++ b/arith/src/ring_nq.rs
@@ -22,8 +22,8 @@ use crate::Ring;
 /// The implementation assumes that q is prime.
 #[derive(Clone)]
 pub struct Rq {
-    pub(crate) q: u64, // TODO think if really needed or it's fine with coeffs[0].q
-    pub(crate) n: usize,
+    pub q: u64, // TODO think if really needed or it's fine with coeffs[0].q
+    pub n: usize,
 
     pub(crate) coeffs: Vec<Zq>,
 

--- a/arith/src/ring_nq.rs
+++ b/arith/src/ring_nq.rs
@@ -2,8 +2,10 @@
 //!
 
 use anyhow::{anyhow, Result};
+use itertools::zip_eq;
 use rand::{distributions::Distribution, Rng};
 use std::array;
+use std::borrow::Borrow;
 use std::fmt;
 use std::iter::Sum;
 use std::ops::{Add, AddAssign, Mul, Neg, Sub, SubAssign};
@@ -18,75 +20,91 @@ use crate::Ring;
 // use Vec.
 /// PolynomialRing element, where the PolynomialRing is R = Z_q[X]/(X^n +1)
 /// The implementation assumes that q is prime.
-#[derive(Clone, Copy)]
-pub struct Rq<const Q: u64, const N: usize> {
-    pub(crate) coeffs: [Zq<Q>; N],
+#[derive(Clone)]
+pub struct Rq {
+    pub(crate) q: u64, // TODO think if really needed or it's fine with coeffs[0].q
+    pub(crate) n: usize,
+
+    pub(crate) coeffs: Vec<Zq>,
 
     // evals are set when doig a PRxPR multiplication, so it can be reused in future
     // multiplications avoiding recomputing it
-    pub(crate) evals: Option<[Zq<Q>; N]>,
+    pub(crate) evals: Option<Vec<Zq>>,
 }
 
-impl<const Q: u64, const N: usize> Ring for Rq<Q, N> {
-    type C = Zq<Q>;
-
-    const Q: u64 = Q;
-    const N: usize = N;
+impl Ring for Rq {
+    type C = Zq;
+    type Params = (u64, usize);
 
     fn coeffs(&self) -> Vec<Self::C> {
         self.coeffs.to_vec()
     }
-    fn zero() -> Self {
-        let coeffs = array::from_fn(|_| Zq::zero());
+    // fn zero(q: u64, n: usize) -> Self {
+    fn zero(param: (u64, usize)) -> Self {
+        let (q, n) = param;
         Self {
-            coeffs,
+            q,
+            n,
+            coeffs: vec![Zq::zero(q); n],
             evals: None,
         }
     }
-    fn rand(mut rng: impl Rng, dist: impl Distribution<f64>) -> Self {
+    fn rand(mut rng: impl Rng, dist: impl Distribution<f64>, params: Self::Params) -> Self {
         // let coeffs: [Zq<Q>; N] = array::from_fn(|_| Zq::from_u64(dist.sample(&mut rng)));
-        let coeffs: [Zq<Q>; N] = array::from_fn(|_| Self::C::rand(&mut rng, &dist));
+        // let coeffs: [Zq<Q>; N] = array::from_fn(|_| Self::C::rand(&mut rng, &dist));
+        let (q, n) = params;
         Self {
-            coeffs,
+            q,
+            n,
+            coeffs: std::iter::repeat_with(|| Self::C::rand(&mut rng, &dist, q))
+                .take(n)
+                .collect(),
             evals: None,
         }
     }
 
-    fn from_vec(coeffs: Vec<Zq<Q>>) -> Self {
+    fn from_vec(params: Self::Params, coeffs: Vec<Zq>) -> Self {
+        let (q, n) = params;
         let mut p = coeffs;
-        modulus::<Q, N>(&mut p);
-        let coeffs = array::from_fn(|i| p[i]);
+        modulus(q, n, &mut p);
         Self {
-            coeffs,
+            q,
+            n,
+            coeffs: p,
             evals: None,
         }
     }
 
     // returns the decomposition of each polynomial coefficient, such
-    // decomposition will be a vecotor of length N, containint N vectors of Zq
+    // decomposition will be a vector of length N, containing N vectors of Zq
     fn decompose(&self, beta: u32, l: u32) -> Vec<Self> {
-        let elems: Vec<Vec<Zq<Q>>> = self.coeffs.iter().map(|r| r.decompose(beta, l)).collect();
+        let elems: Vec<Vec<Zq>> = self.coeffs.iter().map(|r| r.decompose(beta, l)).collect();
         // transpose it
-        let r: Vec<Vec<Zq<Q>>> = (0..elems[0].len())
+        let r: Vec<Vec<Zq>> = (0..elems[0].len())
             .map(|i| (0..elems.len()).map(|j| elems[j][i]).collect())
             .collect();
         // convert it to Rq<Q,N>
-        r.iter().map(|a_i| Self::from_vec(a_i.clone())).collect()
+        r.iter()
+            .map(|a_i| Self::from_vec((self.q, self.n), a_i.clone()))
+            .collect()
     }
 
     // Warning: this method will behave differently depending on the values P and Q:
     // if Q<P, it just 'renames' the modulus parameter to P
     // if Q>=P, it crops to mod P
-    fn remodule<const P: u64>(&self) -> Rq<P, N> {
-        Rq::<P, N>::from_vec_u64(self.coeffs().iter().map(|m_i| m_i.0).collect())
+    fn remodule(&self, p: u64) -> Rq {
+        Rq::from_vec_u64(p, self.n, self.coeffs().iter().map(|m_i| m_i.v).collect())
     }
 
     /// perform the mod switch operation from Q to Q', where Q2=Q'
     // fn mod_switch<const P: u64, const M: usize>(&self) -> impl Ring {
-    fn mod_switch<const P: u64>(&self) -> Rq<P, N> {
+    fn mod_switch(&self, p: u64) -> Rq {
         // assert_eq!(N, M); // sanity check
-        Rq::<P, N> {
-            coeffs: array::from_fn(|i| self.coeffs[i].mod_switch::<P>()),
+        Rq {
+            q: p,
+            n: self.n,
+            // coeffs: array::from_fn(|i| self.coeffs[i].mod_switch::<P>()),
+            coeffs: self.coeffs.iter().map(|c_i| c_i.mod_switch(p)).collect(),
             evals: None,
         }
     }
@@ -98,45 +116,49 @@ impl<const Q: u64, const N: usize> Ring for Rq<Q, N> {
         let r: Vec<f64> = self
             .coeffs()
             .iter()
-            .map(|e| ((num as f64 * e.0 as f64) / den as f64).round())
+            .map(|e| ((num as f64 * e.v as f64) / den as f64).round())
             .collect();
-        Rq::<Q, N>::from_vec_f64(r)
+        Rq::from_vec_f64(self.q, self.n, r)
     }
 }
 
-impl<const Q: u64, const N: usize> From<crate::ring_n::R<N>> for Rq<Q, N> {
-    fn from(r: crate::ring_n::R<N>) -> Self {
+impl From<(u64, crate::ring_n::R)> for Rq {
+    fn from(qr: (u64, crate::ring_n::R)) -> Self {
+        let (q, r) = qr;
+        assert_eq!(r.n, r.coeffs.len());
+
         Self::from_vec(
+            (q, r.n),
             r.coeffs()
                 .iter()
-                .map(|e| Zq::<Q>::from_f64(*e as f64))
+                .map(|e| Zq::from_f64(q, *e as f64))
                 .collect(),
         )
     }
 }
 
 // apply mod (X^N+1)
-pub fn modulus<const Q: u64, const N: usize>(p: &mut Vec<Zq<Q>>) {
-    if p.len() < N {
+pub fn modulus(q: u64, n: usize, p: &mut Vec<Zq>) {
+    if p.len() < n {
         return;
     }
-    for i in N..p.len() {
-        p[i - N] = p[i - N].clone() - p[i].clone();
-        p[i] = Zq(0);
+    for i in n..p.len() {
+        p[i - n] = p[i - n].clone() - p[i].clone();
+        p[i] = Zq::zero(q);
     }
-    p.truncate(N);
+    p.truncate(n);
 }
 
-// PR stands for PolynomialRing
-impl<const Q: u64, const N: usize> Rq<Q, N> {
-    pub fn coeffs(&self) -> [Zq<Q>; N] {
-        self.coeffs
+impl Rq {
+    pub fn coeffs(&self) -> Vec<Zq> {
+        self.coeffs.clone()
     }
     pub fn compute_evals(&mut self) {
-        self.evals = Some(NTT::<Q, N>::ntt(self.coeffs));
+        self.evals = Some(NTT::ntt(self).coeffs); // TODO improve, ntt returns Rq but here
+                                                  // just needs Vec<Zq>
     }
-    pub fn to_r(self) -> crate::R<N> {
-        crate::R::<N>::from(self)
+    pub fn to_r(self) -> crate::R {
+        crate::R::from(self)
     }
 
     // TODO rm since it is implemented in Ring trait impl
@@ -148,55 +170,105 @@ impl<const Q: u64, const N: usize> Rq<Q, N> {
     //     }
     // }
     // this method is mostly for tests
-    pub fn from_vec_u64(coeffs: Vec<u64>) -> Self {
-        let coeffs_mod_q = coeffs.iter().map(|c| Zq::from_u64(*c)).collect();
-        Self::from_vec(coeffs_mod_q)
+    pub fn from_vec_u64(q: u64, n: usize, coeffs: Vec<u64>) -> Self {
+        let coeffs_mod_q: Vec<Zq> = coeffs.iter().map(|c| Zq::from_u64(q, *c)).collect();
+        Self::from_vec((q, n), coeffs_mod_q)
     }
-    pub fn from_vec_f64(coeffs: Vec<f64>) -> Self {
-        let coeffs_mod_q = coeffs.iter().map(|c| Zq::from_f64(*c)).collect();
-        Self::from_vec(coeffs_mod_q)
+    pub fn from_vec_f64(q: u64, n: usize, coeffs: Vec<f64>) -> Self {
+        let coeffs_mod_q: Vec<Zq> = coeffs.iter().map(|c| Zq::from_f64(q, *c)).collect();
+        Self::from_vec((q, n), coeffs_mod_q)
     }
-    pub fn from_vec_i64(coeffs: Vec<i64>) -> Self {
-        let coeffs_mod_q = coeffs.iter().map(|c| Zq::from_f64(*c as f64)).collect();
-        Self::from_vec(coeffs_mod_q)
+    pub fn from_vec_i64(q: u64, n: usize, coeffs: Vec<i64>) -> Self {
+        let coeffs_mod_q: Vec<Zq> = coeffs.iter().map(|c| Zq::from_f64(q, *c as f64)).collect();
+        Self::from_vec((q, n), coeffs_mod_q)
     }
-    pub fn new(coeffs: [Zq<Q>; N], evals: Option<[Zq<Q>; N]>) -> Self {
-        Self { coeffs, evals }
+    pub fn new(q: u64, n: usize, coeffs: Vec<Zq>, evals: Option<Vec<Zq>>) -> Self {
+        Self {
+            q,
+            n,
+            coeffs,
+            evals,
+        }
     }
 
-    pub fn rand_abs(mut rng: impl Rng, dist: impl Distribution<f64>) -> Result<Self> {
-        let coeffs: [Zq<Q>; N] = array::from_fn(|_| Zq::from_f64(dist.sample(&mut rng).abs()));
+    pub fn rand_abs(
+        mut rng: impl Rng,
+        dist: impl Distribution<f64>,
+        q: u64,
+        n: usize,
+    ) -> Result<Self> {
+        // let coeffs: [Zq<Q>; N] = array::from_fn(|_| Zq::from_f64(dist.sample(&mut rng).abs()));
         Ok(Self {
-            coeffs,
+            q,
+            n,
+            coeffs: std::iter::repeat_with(|| Zq::from_f64(q, dist.sample(&mut rng).abs()))
+                .take(n)
+                .collect(),
             evals: None,
         })
     }
-    pub fn rand_f64_abs(mut rng: impl Rng, dist: impl Distribution<f64>) -> Result<Self> {
-        let coeffs: [Zq<Q>; N] = array::from_fn(|_| Zq::from_f64(dist.sample(&mut rng).abs()));
+    pub fn rand_f64_abs(
+        mut rng: impl Rng,
+        dist: impl Distribution<f64>,
+        q: u64,
+        n: usize,
+    ) -> Result<Self> {
+        // let coeffs: [Zq<Q>; N] = array::from_fn(|_| Zq::from_f64(dist.sample(&mut rng).abs()));
         Ok(Self {
-            coeffs,
+            q,
+            n,
+            coeffs: std::iter::repeat_with(|| Zq::from_f64(q, dist.sample(&mut rng).abs()))
+                .take(n)
+                .collect(),
             evals: None,
         })
     }
-    pub fn rand_f64(mut rng: impl Rng, dist: impl Distribution<f64>) -> Result<Self> {
-        let coeffs: [Zq<Q>; N] = array::from_fn(|_| Zq::from_f64(dist.sample(&mut rng)));
+    pub fn rand_f64(
+        mut rng: impl Rng,
+        dist: impl Distribution<f64>,
+        q: u64,
+        n: usize,
+    ) -> Result<Self> {
+        // let coeffs: [Zq<Q>; N] = array::from_fn(|_| Zq::from_f64(dist.sample(&mut rng)));
         Ok(Self {
-            coeffs,
+            q,
+            n,
+            coeffs: std::iter::repeat_with(|| Zq::from_f64(q, dist.sample(&mut rng)))
+                .take(n)
+                .collect(),
             evals: None,
         })
     }
-    pub fn rand_u64(mut rng: impl Rng, dist: impl Distribution<u64>) -> Result<Self> {
-        let coeffs: [Zq<Q>; N] = array::from_fn(|_| Zq::from_u64(dist.sample(&mut rng)));
+    pub fn rand_u64(
+        mut rng: impl Rng,
+        dist: impl Distribution<u64>,
+        q: u64,
+        n: usize,
+    ) -> Result<Self> {
+        // let coeffs: [Zq<Q>; N] = array::from_fn(|_| Zq::from_u64(dist.sample(&mut rng)));
         Ok(Self {
-            coeffs,
+            q,
+            n,
+            coeffs: std::iter::repeat_with(|| Zq::from_u64(q, dist.sample(&mut rng)))
+                .take(n)
+                .collect(),
             evals: None,
         })
     }
     // WIP. returns random v \in {0,1}. // TODO {-1, 0, 1}
-    pub fn rand_bin(mut rng: impl Rng, dist: impl Distribution<bool>) -> Result<Self> {
-        let coeffs: [Zq<Q>; N] = array::from_fn(|_| Zq::from_bool(dist.sample(&mut rng)));
+    pub fn rand_bin(
+        mut rng: impl Rng,
+        dist: impl Distribution<bool>,
+        q: u64,
+        n: usize,
+    ) -> Result<Self> {
+        // let coeffs: [Zq<Q>; N] = array::from_fn(|_| Zq::from_bool(dist.sample(&mut rng)));
         Ok(Rq {
-            coeffs,
+            q,
+            n,
+            coeffs: std::iter::repeat_with(|| Zq::from_bool(q, dist.sample(&mut rng)))
+                .take(n)
+                .collect(),
             evals: None,
         })
     }
@@ -208,36 +280,50 @@ impl<const Q: u64, const N: usize> Rq<Q, N> {
     // }
 
     // applies mod(T) to all coefficients of self
-    pub fn coeffs_mod<const T: u64>(&self) -> Self {
-        Rq::<Q, N>::from_vec_u64(
+    pub fn coeffs_mod<const T: u64>(&self, q: u64, n: usize, t: u64) -> Self {
+        Rq::from_vec_u64(
+            q,
+            n,
             self.coeffs()
                 .iter()
-                .map(|m_i| modulus_u64::<T>(m_i.0))
+                .map(|m_i| modulus_u64(t, m_i.v))
                 .collect(),
         )
     }
 
     // TODO review if needed, or if with this interface
-    pub fn mul_by_matrix(&self, m: &Vec<Vec<Zq<Q>>>) -> Result<Vec<Zq<Q>>> {
+    pub fn mul_by_matrix(&self, m: &Vec<Vec<Zq>>) -> Result<Vec<Zq>> {
         matrix_vec_product(m, &self.coeffs.to_vec())
     }
-    pub fn mul_by_zq(&self, s: &Zq<Q>) -> Self {
+    pub fn mul_by_zq(&self, s: &Zq) -> Self {
         Self {
-            coeffs: array::from_fn(|i| self.coeffs[i] * *s),
+            q: self.q,
+            n: self.n,
+            // coeffs: array::from_fn(|i| self.coeffs[i] * *s),
+            coeffs: self.coeffs.iter().map(|c_i| *c_i * *s).collect(),
             evals: None,
         }
     }
     pub fn mul_by_u64(&self, s: u64) -> Self {
-        let s = Zq::from_u64(s);
+        let s = Zq::from_u64(self.q, s);
         Self {
-            coeffs: array::from_fn(|i| self.coeffs[i] * s),
-            // coeffs: self.coeffs.iter().map(|&e| e * s).collect(),
+            q: self.q,
+            n: self.n,
+            // coeffs: array::from_fn(|i| self.coeffs[i] * s),
+            coeffs: self.coeffs.iter().map(|&e| e * s).collect(),
             evals: None,
         }
     }
     pub fn mul_by_f64(&self, s: f64) -> Self {
         Self {
-            coeffs: array::from_fn(|i| Zq::from_f64(self.coeffs[i].0 as f64 * s)),
+            q: self.q,
+            n: self.n,
+            // coeffs: array::from_fn(|i| Zq::from_f64(self.coeffs[i].0 as f64 * s)),
+            coeffs: self
+                .coeffs
+                .iter()
+                .map(|c_i| Zq::from_f64(self.q, c_i.v as f64 * s))
+                .collect(),
             evals: None,
         }
     }
@@ -251,9 +337,9 @@ impl<const Q: u64, const N: usize> Rq<Q, N> {
         let r: Vec<f64> = self
             .coeffs()
             .iter()
-            .map(|e| (e.0 as f64 / s as f64).round())
+            .map(|e| (e.v as f64 / s as f64).round())
             .collect();
-        Rq::<Q, N>::from_vec_f64(r)
+        Rq::from_vec_f64(self.q, self.n, r)
     }
 
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -261,19 +347,19 @@ impl<const Q: u64, const N: usize> Rq<Q, N> {
         let mut str = "";
         let mut zero = true;
         for (i, coeff) in self.coeffs.iter().enumerate().rev() {
-            if coeff.0 == 0 {
+            if coeff.v == 0 {
                 continue;
             }
             zero = false;
             f.write_str(str)?;
-            if coeff.0 != 1 {
-                f.write_str(coeff.0.to_string().as_str())?;
+            if coeff.v != 1 {
+                f.write_str(coeff.v.to_string().as_str())?;
                 if i > 0 {
                     f.write_str("*")?;
                 }
             }
-            if coeff.0 == 1 && i == 0 {
-                f.write_str(coeff.0.to_string().as_str())?;
+            if coeff.v == 1 && i == 0 {
+                f.write_str(coeff.v.to_string().as_str())?;
             }
             if i == 1 {
                 f.write_str("x")?;
@@ -288,9 +374,9 @@ impl<const Q: u64, const N: usize> Rq<Q, N> {
         }
 
         f.write_str(" mod Z_")?;
-        f.write_str(Q.to_string().as_str())?;
+        f.write_str(self.q.to_string().as_str())?;
         f.write_str("/(X^")?;
-        f.write_str(N.to_string().as_str())?;
+        f.write_str(self.n.to_string().as_str())?;
         f.write_str("+1)")?;
         Ok(())
     }
@@ -298,16 +384,20 @@ impl<const Q: u64, const N: usize> Rq<Q, N> {
     pub fn infinity_norm(&self) -> u64 {
         self.coeffs()
             .iter()
-            .map(|x| if x.0 > (Q / 2) { Q - x.0 } else { x.0 })
+            .map(|x| {
+                if x.v > (self.q / 2) {
+                    self.q - x.v
+                } else {
+                    x.v
+                }
+            })
             .fold(0, |a, b| a.max(b))
     }
-    pub fn mod_centered_q(&self) -> crate::ring_n::R<N> {
-        self.to_r().mod_centered_q::<Q>()
+    pub fn mod_centered_q(&self) -> crate::ring_n::R {
+        self.clone().to_r().mod_centered_q(self.q)
     }
 }
-pub fn matrix_vec_product<const Q: u64>(m: &Vec<Vec<Zq<Q>>>, v: &Vec<Zq<Q>>) -> Result<Vec<Zq<Q>>> {
-    // assert_eq!(m.len(), m[0].len()); // TODO change to returning err
-    // assert_eq!(m.len(), v.len());
+pub fn matrix_vec_product(m: &Vec<Vec<Zq>>, v: &Vec<Zq>) -> Result<Vec<Zq>> {
     if m.len() != m[0].len() {
         return Err(anyhow!("expected 'm' to be a square matrix"));
     }
@@ -319,6 +409,8 @@ pub fn matrix_vec_product<const Q: u64>(m: &Vec<Vec<Zq<Q>>>, v: &Vec<Zq<Q>>) -> 
         ));
     }
 
+    assert_eq!(m[0][0].q, v[0].q); // TODO change to returning err
+
     Ok(m.iter()
         .map(|row| {
             row.iter()
@@ -326,12 +418,15 @@ pub fn matrix_vec_product<const Q: u64>(m: &Vec<Vec<Zq<Q>>>, v: &Vec<Zq<Q>>) -> 
                 .map(|(&row_i, &v_i)| row_i * v_i)
                 .sum()
         })
-        .collect::<Vec<Zq<Q>>>())
+        .collect::<Vec<Zq>>())
 }
-pub fn transpose<const Q: u64>(m: &[Vec<Zq<Q>>]) -> Vec<Vec<Zq<Q>>> {
+pub fn transpose(m: &[Vec<Zq>]) -> Vec<Vec<Zq>> {
+    assert!(m.len() > 0);
+    assert!(m[0].len() > 0);
+    let q = m[0][0].q;
     // TODO case when m[0].len()=0
     // TODO non square matrix
-    let mut r: Vec<Vec<Zq<Q>>> = vec![vec![Zq(0); m[0].len()]; m.len()];
+    let mut r: Vec<Vec<Zq>> = vec![vec![Zq::zero(q); m[0].len()]; m.len()];
     for (i, m_row) in m.iter().enumerate() {
         for (j, m_ij) in m_row.iter().enumerate() {
             r[j][i] = *m_ij;
@@ -340,17 +435,24 @@ pub fn transpose<const Q: u64>(m: &[Vec<Zq<Q>>]) -> Vec<Vec<Zq<Q>>> {
     r
 }
 
-impl<const Q: u64, const N: usize> PartialEq for Rq<Q, N> {
+impl PartialEq for Rq {
     fn eq(&self, other: &Self) -> bool {
-        self.coeffs == other.coeffs
+        self.coeffs == other.coeffs && self.q == other.q && self.n == other.n
     }
 }
-impl<const Q: u64, const N: usize> Add<Rq<Q, N>> for Rq<Q, N> {
+impl Add<Rq> for Rq {
     type Output = Self;
 
     fn add(self, rhs: Self) -> Self {
+        assert_eq!(self.q, rhs.q);
+        assert_eq!(self.n, rhs.n);
         Self {
-            coeffs: array::from_fn(|i| self.coeffs[i] + rhs.coeffs[i]),
+            q: self.q,
+            n: self.n,
+            // coeffs: array::from_fn(|i| self.coeffs[i] + rhs.coeffs[i]),
+            coeffs: zip_eq(self.coeffs, rhs.coeffs)
+                .map(|(l, r)| l + r)
+                .collect(),
             evals: None,
         }
         // Self {
@@ -365,180 +467,227 @@ impl<const Q: u64, const N: usize> Add<Rq<Q, N>> for Rq<Q, N> {
         // Self(r.iter_mut().map(|e| e.r#mod()).collect()) // TODO mod should happen auto in +
     }
 }
-impl<const Q: u64, const N: usize> Add<&Rq<Q, N>> for &Rq<Q, N> {
-    type Output = Rq<Q, N>;
+impl Add<&Rq> for &Rq {
+    type Output = Rq;
 
-    fn add(self, rhs: &Rq<Q, N>) -> Self::Output {
+    fn add(self, rhs: &Rq) -> Self::Output {
+        assert_eq!(self.q, rhs.q);
+        assert_eq!(self.n, rhs.n);
         Rq {
-            coeffs: array::from_fn(|i| self.coeffs[i] + rhs.coeffs[i]),
+            q: self.q,
+            n: self.n,
+            // coeffs: array::from_fn(|i| self.coeffs[i] + rhs.coeffs[i]),
+            coeffs: zip_eq(self.coeffs.clone(), rhs.coeffs.clone())
+                .map(|(l, r)| l + r)
+                .collect(),
             evals: None,
         }
     }
 }
-impl<const Q: u64, const N: usize> AddAssign for Rq<Q, N> {
+impl AddAssign for Rq {
     fn add_assign(&mut self, rhs: Self) {
-        for i in 0..N {
+        debug_assert_eq!(self.q, rhs.q);
+        debug_assert_eq!(self.n, rhs.n);
+        for i in 0..self.n {
             self.coeffs[i] += rhs.coeffs[i];
         }
     }
 }
 
-impl<const Q: u64, const N: usize> Sum<Rq<Q, N>> for Rq<Q, N> {
-    fn sum<I>(iter: I) -> Self
+impl Sum<Rq> for Rq {
+    fn sum<I>(mut iter: I) -> Self
     where
         I: Iterator<Item = Self>,
     {
-        let mut acc = Rq::<Q, N>::zero();
-        for e in iter {
-            acc += e;
-        }
-        acc
+        // let mut acc = Rq::zero();
+        // for e in iter {
+        //     acc += e;
+        // }
+        // acc
+        let first = iter.next().unwrap();
+        iter.fold(first, |acc, x| acc + x)
     }
 }
 
-impl<const Q: u64, const N: usize> Sub<Rq<Q, N>> for Rq<Q, N> {
+impl Sub<Rq> for Rq {
     type Output = Self;
 
     fn sub(self, rhs: Self) -> Self {
+        assert_eq!(self.q, rhs.q);
+        assert_eq!(self.n, rhs.n);
         Self {
-            coeffs: array::from_fn(|i| self.coeffs[i] - rhs.coeffs[i]),
+            q: self.q,
+            n: self.n,
+            // coeffs: array::from_fn(|i| self.coeffs[i] - rhs.coeffs[i]),
+            coeffs: zip_eq(self.coeffs, rhs.coeffs)
+                .map(|(l, r)| l - r)
+                .collect(),
             evals: None,
         }
     }
 }
-impl<const Q: u64, const N: usize> Sub<&Rq<Q, N>> for &Rq<Q, N> {
-    type Output = Rq<Q, N>;
+impl Sub<&Rq> for &Rq {
+    type Output = Rq;
 
-    fn sub(self, rhs: &Rq<Q, N>) -> Self::Output {
+    fn sub(self, rhs: &Rq) -> Self::Output {
+        assert_eq!(self.q, rhs.q); // TODO replace all those with debug_assert_eq
+        debug_assert_eq!(self.n, rhs.n);
         Rq {
-            coeffs: array::from_fn(|i| self.coeffs[i] - rhs.coeffs[i]),
+            q: self.q,
+            n: self.n,
+            // coeffs: array::from_fn(|i| self.coeffs[i] - rhs.coeffs[i]),
+            coeffs: zip_eq(self.coeffs.clone(), rhs.coeffs.clone())
+                .map(|(l, r)| l - r)
+                .collect(),
             evals: None,
         }
     }
 }
-impl<const Q: u64, const N: usize> SubAssign for Rq<Q, N> {
+impl SubAssign for Rq {
     fn sub_assign(&mut self, rhs: Self) {
-        for i in 0..N {
+        debug_assert_eq!(self.q, rhs.q);
+        debug_assert_eq!(self.n, rhs.n);
+        for i in 0..self.n {
             self.coeffs[i] -= rhs.coeffs[i];
         }
     }
 }
 
-impl<const Q: u64, const N: usize> Mul<Rq<Q, N>> for Rq<Q, N> {
+impl Mul<Rq> for Rq {
     type Output = Self;
 
     fn mul(self, rhs: Self) -> Self {
         mul(&self, &rhs)
     }
 }
-impl<const Q: u64, const N: usize> Mul<&Rq<Q, N>> for &Rq<Q, N> {
-    type Output = Rq<Q, N>;
+impl Mul<&Rq> for &Rq {
+    type Output = Rq;
 
-    fn mul(self, rhs: &Rq<Q, N>) -> Self::Output {
+    fn mul(self, rhs: &Rq) -> Self::Output {
         mul(self, rhs)
     }
 }
 
 // mul by Zq element
-impl<const Q: u64, const N: usize> Mul<Zq<Q>> for Rq<Q, N> {
+impl Mul<Zq> for Rq {
     type Output = Self;
 
-    fn mul(self, s: Zq<Q>) -> Self {
+    fn mul(self, s: Zq) -> Self {
         self.mul_by_zq(&s)
     }
 }
-impl<const Q: u64, const N: usize> Mul<&Zq<Q>> for &Rq<Q, N> {
-    type Output = Rq<Q, N>;
+impl Mul<&Zq> for &Rq {
+    type Output = Rq;
 
-    fn mul(self, s: &Zq<Q>) -> Self::Output {
+    fn mul(self, s: &Zq) -> Self::Output {
         self.mul_by_zq(s)
     }
 }
 // mul by u64
-impl<const Q: u64, const N: usize> Mul<u64> for Rq<Q, N> {
+impl Mul<u64> for Rq {
     type Output = Self;
 
     fn mul(self, s: u64) -> Self {
         self.mul_by_u64(s)
     }
 }
-impl<const Q: u64, const N: usize> Mul<&u64> for &Rq<Q, N> {
-    type Output = Rq<Q, N>;
+impl Mul<&u64> for &Rq {
+    type Output = Rq;
 
     fn mul(self, s: &u64) -> Self::Output {
         self.mul_by_u64(*s)
     }
 }
 // mul by f64
-impl<const Q: u64, const N: usize> Mul<f64> for Rq<Q, N> {
+impl Mul<f64> for Rq {
     type Output = Self;
 
     fn mul(self, s: f64) -> Self {
         self.mul_by_f64(s)
     }
 }
-impl<const Q: u64, const N: usize> Mul<&f64> for &Rq<Q, N> {
-    type Output = Rq<Q, N>;
+impl Mul<&f64> for &Rq {
+    type Output = Rq;
 
     fn mul(self, s: &f64) -> Self::Output {
         self.mul_by_f64(*s)
     }
 }
 
-impl<const Q: u64, const N: usize> Neg for Rq<Q, N> {
+impl Neg for Rq {
     type Output = Self;
 
     fn neg(self) -> Self::Output {
         Self {
-            coeffs: array::from_fn(|i| -self.coeffs[i]),
+            q: self.q,
+            n: self.n,
+            // coeffs: array::from_fn(|i| -self.coeffs[i]),
+            // coeffs: self.coeffs.iter().map(|c_i| -c_i).collect(),
+            coeffs: self.coeffs.iter().map(|c_i| -*c_i).collect(),
             evals: None,
         }
     }
 }
 
 // note: this assumes that Q is prime
-fn mul_mut<const Q: u64, const N: usize>(lhs: &mut Rq<Q, N>, rhs: &mut Rq<Q, N>) -> Rq<Q, N> {
+fn mul_mut(lhs: &mut Rq, rhs: &mut Rq) -> Rq {
+    assert_eq!(lhs.q, rhs.q);
+    assert_eq!(lhs.n, rhs.n);
+    let (q, n) = (lhs.q, lhs.n);
+
     // reuse evaluations if already computed
     if !lhs.evals.is_some() {
-        lhs.evals = Some(NTT::<Q, N>::ntt(lhs.coeffs));
+        lhs.evals = Some(NTT::ntt(lhs).coeffs);
     };
     if !rhs.evals.is_some() {
-        rhs.evals = Some(NTT::<Q, N>::ntt(rhs.coeffs));
+        rhs.evals = Some(NTT::ntt(rhs).coeffs);
     };
-    let lhs_evals = lhs.evals.unwrap();
-    let rhs_evals = rhs.evals.unwrap();
+    let lhs_evals = lhs.evals.clone().unwrap();
+    let rhs_evals = rhs.evals.clone().unwrap();
 
-    let c_ntt: [Zq<Q>; N] = array::from_fn(|i| lhs_evals[i] * rhs_evals[i]);
-    let c = NTT::<Q, { N }>::intt(c_ntt);
-    Rq::new(c, Some(c_ntt))
+    // let c_ntt: [Zq<Q>; N] = array::from_fn(|i| lhs_evals[i] * rhs_evals[i]);
+    let c_ntt: Rq = Rq::from_vec(
+        (q, n),
+        zip_eq(lhs_evals, rhs_evals).map(|(l, r)| l * r).collect(),
+    );
+    let c = NTT::intt(&c_ntt);
+    Rq::new(q, n, c.coeffs, Some(c_ntt.coeffs))
 }
 // note: this assumes that Q is prime
 // TODO impl karatsuba for non-prime Q
-fn mul<const Q: u64, const N: usize>(lhs: &Rq<Q, N>, rhs: &Rq<Q, N>) -> Rq<Q, N> {
+fn mul(lhs: &Rq, rhs: &Rq) -> Rq {
+    assert_eq!(lhs.q, rhs.q);
+    assert_eq!(lhs.n, rhs.n);
+    let (q, n) = (lhs.q, lhs.n);
+
     // reuse evaluations if already computed
-    let lhs_evals = if lhs.evals.is_some() {
-        lhs.evals.unwrap()
+    let lhs_evals: Vec<Zq> = if lhs.evals.is_some() {
+        lhs.evals.clone().unwrap()
     } else {
-        NTT::<Q, N>::ntt(lhs.coeffs)
+        NTT::ntt(lhs).coeffs
     };
-    let rhs_evals = if rhs.evals.is_some() {
-        rhs.evals.unwrap()
+    let rhs_evals: Vec<Zq> = if rhs.evals.is_some() {
+        rhs.evals.clone().unwrap()
     } else {
-        NTT::<Q, N>::ntt(rhs.coeffs)
+        NTT::ntt(rhs).coeffs
     };
 
-    let c_ntt: [Zq<Q>; N] = array::from_fn(|i| lhs_evals[i] * rhs_evals[i]);
-    let c = NTT::<Q, { N }>::intt(c_ntt);
-    Rq::new(c, Some(c_ntt))
+    // let c_ntt: [Zq<Q>; N] = array::from_fn(|i| lhs_evals[i] * rhs_evals[i]);
+    let c_ntt: Rq = Rq::from_vec(
+        (q, n),
+        zip_eq(lhs_evals, rhs_evals).map(|(l, r)| l * r).collect(),
+    );
+    let c = NTT::intt(&c_ntt);
+    Rq::new(q, n, c.coeffs, Some(c_ntt.coeffs))
 }
 
-impl<const Q: u64, const N: usize> fmt::Display for Rq<Q, N> {
+impl fmt::Display for Rq {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.fmt(f)?;
         Ok(())
     }
 }
-impl<const Q: u64, const N: usize> fmt::Debug for Rq<Q, N> {
+impl fmt::Debug for Rq {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.fmt(f)?;
         Ok(())
@@ -552,31 +701,31 @@ mod tests {
     #[test]
     fn test_polynomial_ring() {
         // the test values used are generated with SageMath
-        const Q: u64 = 7;
-        const N: usize = 3;
+        let q: u64 = 7;
+        let n: usize = 3;
 
         // p = 1x + 2x^2 + 3x^3 + 4 x^4 + 5 x^5 in R=Z_q[X]/(X^n +1)
-        let p = Rq::<Q, N>::from_vec_u64(vec![0u64, 1, 2, 3, 4, 5]);
+        let p = Rq::from_vec_u64(q, n, vec![0u64, 1, 2, 3, 4, 5]);
         assert_eq!(p.to_string(), "4*x^2 + 4*x + 4 mod Z_7/(X^3+1)");
 
         // try with coefficients bigger than Q
-        let p = Rq::<Q, N>::from_vec_u64(vec![0u64, 1, Q + 2, 3, 4, 5]);
+        let p = Rq::from_vec_u64(q, n, vec![0u64, 1, q + 2, 3, 4, 5]);
         assert_eq!(p.to_string(), "4*x^2 + 4*x + 4 mod Z_7/(X^3+1)");
 
         // try with other ring
-        let p = Rq::<7, 4>::from_vec_u64(vec![0u64, 1, 2, 3, 4, 5]);
+        let p = Rq::from_vec_u64(7, 4, vec![0u64, 1, 2, 3, 4, 5]);
         assert_eq!(p.to_string(), "3*x^3 + 2*x^2 + 3*x + 3 mod Z_7/(X^4+1)");
 
-        let p = Rq::<Q, N>::from_vec_u64(vec![0u64, 0, 0, 0, 4, 5]);
+        let p = Rq::from_vec_u64(q, n, vec![0u64, 0, 0, 0, 4, 5]);
         assert_eq!(p.to_string(), "2*x^2 + 3*x mod Z_7/(X^3+1)");
 
-        let p = Rq::<Q, N>::from_vec_u64(vec![5u64, 4, 5, 2, 1, 0]);
+        let p = Rq::from_vec_u64(q, n, vec![5u64, 4, 5, 2, 1, 0]);
         assert_eq!(p.to_string(), "5*x^2 + 3*x + 3 mod Z_7/(X^3+1)");
 
-        let a = Rq::<Q, N>::from_vec_u64(vec![0u64, 1, 2, 3, 4, 5]);
+        let a = Rq::from_vec_u64(q, n, vec![0u64, 1, 2, 3, 4, 5]);
         assert_eq!(a.to_string(), "4*x^2 + 4*x + 4 mod Z_7/(X^3+1)");
 
-        let b = Rq::<Q, N>::from_vec_u64(vec![5u64, 4, 3, 2, 1, 0]);
+        let b = Rq::from_vec_u64(q, n, vec![5u64, 4, 3, 2, 1, 0]);
         assert_eq!(b.to_string(), "3*x^2 + 3*x + 3 mod Z_7/(X^3+1)");
 
         // add
@@ -593,34 +742,39 @@ mod tests {
 
     #[test]
     fn test_mul() -> Result<()> {
-        const Q: u64 = 2u64.pow(16) + 1;
-        const N: usize = 4;
+        let q: u64 = 2u64.pow(16) + 1;
+        let n: usize = 4;
 
-        let a: [u64; N] = [1u64, 2, 3, 4];
-        let b: [u64; N] = [1u64, 2, 3, 4];
-        let c: [u64; N] = [65513, 65517, 65531, 20];
-        test_mul_opt::<Q, N>(a, b, c)?;
+        let a: Vec<u64> = vec![1u64, 2, 3, 4];
+        let b: Vec<u64> = vec![1u64, 2, 3, 4];
+        let c: Vec<u64> = vec![65513, 65517, 65531, 20];
+        test_mul_opt(q, n, a, b, c)?;
 
-        let a: [u64; N] = [0u64, 0, 0, 2];
-        let b: [u64; N] = [0u64, 0, 0, 2];
-        let c: [u64; N] = [0u64, 0, 65533, 0];
-        test_mul_opt::<Q, N>(a, b, c)?;
+        let a: Vec<u64> = vec![0u64, 0, 0, 2];
+        let b: Vec<u64> = vec![0u64, 0, 0, 2];
+        let c: Vec<u64> = vec![0u64, 0, 65533, 0];
+        test_mul_opt(q, n, a, b, c)?;
 
         // TODO more testvectors
 
         Ok(())
     }
-    fn test_mul_opt<const Q: u64, const N: usize>(
-        a: [u64; N],
-        b: [u64; N],
-        expected_c: [u64; N],
+    fn test_mul_opt(
+        q: u64,
+        n: usize,
+        a: Vec<u64>,
+        b: Vec<u64>,
+        expected_c: Vec<u64>,
     ) -> Result<()> {
-        let a: [Zq<Q>; N] = array::from_fn(|i| Zq::from_u64(a[i]));
-        let mut a = Rq::new(a, None);
-        let b: [Zq<Q>; N] = array::from_fn(|i| Zq::from_u64(b[i]));
-        let mut b = Rq::new(b, None);
-        let expected_c: [Zq<Q>; N] = array::from_fn(|i| Zq::from_u64(expected_c[i]));
-        let expected_c = Rq::new(expected_c, None);
+        assert_eq!(a.len(), n);
+        assert_eq!(b.len(), n);
+
+        // let a: [Zq<Q>; N] = array::from_fn(|i| Zq::from_u64(a[i]));
+        let mut a = Rq::from_vec_u64(q, n, a);
+        // let b: [Zq<Q>; N] = array::from_fn(|i| Zq::from_u64(b[i]));
+        let mut b = Rq::from_vec_u64(q, n, b);
+        // let expected_c: [Zq<Q>; N] = array::from_fn(|i| Zq::from_u64(expected_c[i]));
+        let expected_c = Rq::from_vec_u64(q, n, expected_c);
 
         let c = mul_mut(&mut a, &mut b);
         assert_eq!(c, expected_c);
@@ -629,26 +783,26 @@ mod tests {
 
     #[test]
     fn test_rq_decompose() -> Result<()> {
-        const Q: u64 = 16;
-        const N: usize = 4;
+        let q: u64 = 16;
+        let n: usize = 4;
         let beta = 4;
         let l = 2;
 
-        let a = Rq::<Q, N>::from_vec_u64(vec![7u64, 14, 3, 6]);
+        let a = Rq::from_vec_u64(q, n, vec![7u64, 14, 3, 6]);
         let d = a.decompose(beta, l);
 
         assert_eq!(
-            d[0].coeffs().to_vec(),
+            d[0].coeffs(),
             vec![1u64, 3, 0, 1]
                 .iter()
-                .map(|e| Zq::<Q>::from_u64(*e))
+                .map(|e| Zq::from_u64(q, *e))
                 .collect::<Vec<_>>()
         );
         assert_eq!(
-            d[1].coeffs().to_vec(),
+            d[1].coeffs(),
             vec![3u64, 2, 3, 2]
                 .iter()
-                .map(|e| Zq::<Q>::from_u64(*e))
+                .map(|e| Zq::from_u64(q, *e))
                 .collect::<Vec<_>>()
         );
         Ok(())

--- a/arith/src/ring_torus.rs
+++ b/arith/src/ring_torus.rs
@@ -25,11 +25,14 @@ pub struct Tn {
 
 impl Ring for Tn {
     type C = T64;
-    type Params = usize; // n
+    type Param = usize; // n
 
     // const Q: u64 = u64::MAX; // WIP
     // const N: usize = N;
 
+    fn param(&self) -> Self::Param {
+        self.n
+    }
     fn coeffs(&self) -> Vec<T64> {
         self.coeffs.to_vec()
     }

--- a/arith/src/ring_torus.rs
+++ b/arith/src/ring_torus.rs
@@ -7,6 +7,7 @@
 //! u64, we fit it into the `Ring` trait (from ring.rs) so that we can compose
 //! the 𝕋_<N,q> implementation with the other objects from the code.
 
+use itertools::zip_eq;
 use rand::{distributions::Distribution, Rng};
 use std::array;
 use std::iter::Sum;
@@ -16,54 +17,75 @@ use crate::{ring::Ring, torus::T64, Rq, Zq};
 
 /// 𝕋_<N,Q>[X] = 𝕋<Q>[X]/(X^N +1), polynomials modulo X^N+1 with coefficients in
 /// 𝕋, where Q=2^64.
-#[derive(Clone, Copy, Debug)]
-pub struct Tn<const N: usize>(pub [T64; N]);
+#[derive(Clone, Debug)]
+pub struct Tn {
+    pub n: usize,
+    pub coeffs: Vec<T64>,
+}
 
-impl<const N: usize> Ring for Tn<N> {
+impl Ring for Tn {
     type C = T64;
+    type Params = usize; // n
 
-    const Q: u64 = u64::MAX; // WIP
-    const N: usize = N;
+    // const Q: u64 = u64::MAX; // WIP
+    // const N: usize = N;
 
     fn coeffs(&self) -> Vec<T64> {
-        self.0.to_vec()
+        self.coeffs.to_vec()
     }
 
-    fn zero() -> Self {
-        Self(array::from_fn(|_| T64::zero()))
+    fn zero(n: usize) -> Self {
+        Self {
+            n,
+            coeffs: vec![T64::zero(()); n],
+        }
     }
 
-    fn rand(mut rng: impl Rng, dist: impl Distribution<f64>) -> Self {
-        Self(array::from_fn(|_| T64::rand(&mut rng, &dist)))
+    fn rand(mut rng: impl Rng, dist: impl Distribution<f64>, n: usize) -> Self {
+        Self {
+            n,
+            coeffs: std::iter::repeat_with(|| T64::rand(&mut rng, &dist, ()))
+                .take(n)
+                .collect(),
+        }
+        // Self(array::from_fn(|_| T64::rand(&mut rng, &dist)))
     }
 
-    fn from_vec(coeffs: Vec<Self::C>) -> Self {
+    fn from_vec(n: usize, coeffs: Vec<Self::C>) -> Self {
         let mut p = coeffs;
-        modulus::<N>(&mut p);
-        Self(array::from_fn(|i| p[i]))
+        modulus(n, &mut p);
+        Self { n, coeffs: p }
     }
 
     fn decompose(&self, beta: u32, l: u32) -> Vec<Self> {
-        let elems: Vec<Vec<T64>> = self.0.iter().map(|r| r.decompose(beta, l)).collect();
+        let elems: Vec<Vec<T64>> = self.coeffs.iter().map(|r| r.decompose(beta, l)).collect();
         // transpose it
         let r: Vec<Vec<T64>> = (0..elems[0].len())
             .map(|i| (0..elems.len()).map(|j| elems[j][i]).collect())
             .collect();
-        // convert it to Tn<N>
-        r.iter().map(|a_i| Self::from_vec(a_i.clone())).collect()
+        // convert it to Tn
+        r.iter()
+            .map(|a_i| Self::from_vec(self.n, a_i.clone()))
+            .collect()
     }
 
-    fn remodule<const P: u64>(&self) -> Tn<N> {
+    fn remodule(&self, p: u64) -> Tn {
         todo!()
         // Rq::<P, N>::from_vec_u64(self.coeffs().iter().map(|m_i| m_i.0).collect())
     }
 
     // fn mod_switch<const P: u64>(&self) -> impl Ring {
-    fn mod_switch<const P: u64>(&self) -> Rq<P, N> {
+    fn mod_switch(&self, p: u64) -> Rq {
         // unimplemented!()
         // TODO WIP
-        let coeffs = array::from_fn(|i| Zq::<P>::from_u64(self.0[i].mod_switch::<P>().0));
-        Rq::<P, N> {
+        let coeffs = self
+            .coeffs
+            .iter()
+            .map(|c_i| Zq::from_u64(p, c_i.mod_switch(p).0))
+            .collect();
+        Rq {
+            q: p,
+            n: self.n,
             coeffs,
             evals: None,
         }
@@ -78,175 +100,234 @@ impl<const N: usize> Ring for Tn<N> {
             .iter()
             .map(|e| T64(((num as f64 * e.0 as f64) / den as f64).round() as u64))
             .collect();
-        Self::from_vec(r)
+        Self::from_vec(self.n, r)
     }
 }
 
-impl<const N: usize> Tn<N> {
+impl Tn {
     // multiply self by X^-h
     pub fn left_rotate(&self, h: usize) -> Self {
-        let h = h % N;
-        assert!(h < N);
-        let c = self.0;
+        let n = self.n;
+
+        let h = h % n;
+        assert!(h < n);
+        let c = &self.coeffs;
         // c[h], c[h+1], c[h+2], ..., c[n-1],  -c[0], -c[1], ..., -c[h-1]
         // let r: Vec<T64> = vec![c[h..N], c[0..h].iter().map(|&c_i| -c_i).collect()].concat();
-        let r: Vec<T64> = c[h..N]
+        let r: Vec<T64> = c[h..n]
             .iter()
             .copied()
             .chain(c[0..h].iter().map(|&x| -x))
             .collect();
-        Self::from_vec(r)
+        Self::from_vec(self.n, r)
     }
 
-    pub fn from_vec_u64(v: Vec<u64>) -> Self {
+    pub fn from_vec_u64(n: usize, v: Vec<u64>) -> Self {
         let coeffs = v.iter().map(|c| T64(*c)).collect();
-        Self::from_vec(coeffs)
+        Self::from_vec(n, coeffs)
     }
 }
 
 // apply mod (X^N+1)
-pub fn modulus<const N: usize>(p: &mut Vec<T64>) {
-    if p.len() < N {
+pub fn modulus(n: usize, p: &mut Vec<T64>) {
+    if p.len() < n {
         return;
     }
-    for i in N..p.len() {
-        p[i - N] = p[i - N].clone() - p[i].clone();
-        p[i] = T64::zero();
+    for i in n..p.len() {
+        p[i - n] = p[i - n].clone() - p[i].clone();
+        p[i] = T64::zero(());
     }
-    p.truncate(N);
+    p.truncate(n);
 }
 
-impl<const N: usize> Add<Tn<N>> for Tn<N> {
+impl Add<Tn> for Tn {
     type Output = Self;
 
     fn add(self, rhs: Self) -> Self {
-        Self(array::from_fn(|i| self.0[i] + rhs.0[i]))
+        // Self(array::from_fn(|i| self.0[i] + rhs.0[i]))
+        assert_eq!(self.n, rhs.n);
+        Self {
+            n: self.n,
+            coeffs: zip_eq(self.coeffs, rhs.coeffs)
+                .map(|(l, r)| l + r)
+                .collect(),
+        }
     }
 }
-impl<const N: usize> Add<&Tn<N>> for &Tn<N> {
-    type Output = Tn<N>;
+impl Add<&Tn> for &Tn {
+    type Output = Tn;
 
-    fn add(self, rhs: &Tn<N>) -> Self::Output {
-        Tn(array::from_fn(|i| self.0[i] + rhs.0[i]))
+    fn add(self, rhs: &Tn) -> Self::Output {
+        // Tn(array::from_fn(|i| self.0[i] + rhs.0[i]))
+        assert_eq!(self.n, rhs.n);
+        Tn {
+            n: self.n,
+            coeffs: zip_eq(self.coeffs.clone(), rhs.coeffs.clone())
+                .map(|(l, r)| l + r)
+                .collect(),
+        }
     }
 }
-impl<const N: usize> AddAssign for Tn<N> {
+impl AddAssign for Tn {
     fn add_assign(&mut self, rhs: Self) {
-        for i in 0..N {
-            self.0[i] += rhs.0[i];
+        assert_eq!(self.n, rhs.n);
+        for i in 0..self.n {
+            self.coeffs[i] += rhs.coeffs[i];
         }
     }
 }
 
-impl<const N: usize> Sum<Tn<N>> for Tn<N> {
+impl Sum<Tn> for Tn {
     fn sum<I>(iter: I) -> Self
     where
         I: Iterator<Item = Self>,
     {
-        let mut acc = Tn::<N>::zero();
-        for e in iter {
-            acc += e;
-        }
-        acc
+        // let mut acc = Tn::<N>::zero();
+        // for e in iter {
+        //     acc += e;
+        // }
+        // acc
+        let first = *iter.next().unwrap().borrow();
+        iter.fold(first, |acc, x| acc + x)
     }
 }
 
-impl<const N: usize> Sub<Tn<N>> for Tn<N> {
+impl Sub<Tn> for Tn {
     type Output = Self;
 
     fn sub(self, rhs: Self) -> Self {
-        Self(array::from_fn(|i| self.0[i] - rhs.0[i]))
+        assert_eq!(self.n, rhs.n);
+        Self {
+            n: self.n,
+            coeffs: zip_eq(self.coeffs, rhs.coeffs)
+                .map(|(l, r)| l - r)
+                .collect(),
+        }
     }
 }
-impl<const N: usize> Sub<&Tn<N>> for &Tn<N> {
-    type Output = Tn<N>;
+impl Sub<&Tn> for &Tn {
+    type Output = Tn;
 
-    fn sub(self, rhs: &Tn<N>) -> Self::Output {
-        Tn(array::from_fn(|i| self.0[i] - rhs.0[i]))
-    }
-}
-
-impl<const N: usize> SubAssign for Tn<N> {
-    fn sub_assign(&mut self, rhs: Self) {
-        for i in 0..N {
-            self.0[i] -= rhs.0[i];
+    fn sub(self, rhs: &Tn) -> Self::Output {
+        // Tn(array::from_fn(|i| self.0[i] - rhs.0[i]))
+        assert_eq!(self.n, rhs.n);
+        Tn {
+            n: self.n,
+            coeffs: zip_eq(self.coeffs.clone(), rhs.coeffs.clone())
+                .map(|(l, r)| l - r)
+                .collect(),
         }
     }
 }
 
-impl<const N: usize> Neg for Tn<N> {
+impl SubAssign for Tn {
+    fn sub_assign(&mut self, rhs: Self) {
+        // for i in 0..N {
+        //     self.0[i] -= rhs.0[i];
+        // }
+        assert_eq!(self.n, rhs.n);
+        for i in 0..self.n {
+            self.coeffs[i] -= rhs.coeffs[i];
+        }
+    }
+}
+
+impl Neg for Tn {
     type Output = Self;
 
     fn neg(self) -> Self::Output {
-        Tn(array::from_fn(|i| -self.0[i]))
+        // Tn(array::from_fn(|i| -self.0[i]))
+        Self {
+            n: self.n,
+            coeffs: self.coeffs.iter().map(|c_i| -*c_i).collect(),
+        }
     }
 }
 
-impl<const N: usize> PartialEq for Tn<N> {
+impl PartialEq for Tn {
     fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
+        self.coeffs == other.coeffs && self.n == other.n
     }
 }
 
-impl<const N: usize> Mul<Tn<N>> for Tn<N> {
+impl Mul<Tn> for Tn {
     type Output = Self;
 
     fn mul(self, rhs: Self) -> Self {
         naive_poly_mul(&self, &rhs)
     }
 }
-impl<const N: usize> Mul<&Tn<N>> for &Tn<N> {
-    type Output = Tn<N>;
+impl Mul<&Tn> for &Tn {
+    type Output = Tn;
 
-    fn mul(self, rhs: &Tn<N>) -> Self::Output {
+    fn mul(self, rhs: &Tn) -> Self::Output {
         naive_poly_mul(self, rhs)
     }
 }
 
-fn naive_poly_mul<const N: usize>(poly1: &Tn<N>, poly2: &Tn<N>) -> Tn<N> {
-    let poly1: Vec<u128> = poly1.0.iter().map(|c| c.0 as u128).collect();
-    let poly2: Vec<u128> = poly2.0.iter().map(|c| c.0 as u128).collect();
-    let mut result: Vec<u128> = vec![0; (N * 2) - 1];
-    for i in 0..N {
-        for j in 0..N {
+fn naive_poly_mul(poly1: &Tn, poly2: &Tn) -> Tn {
+    assert_eq!(poly1.n, poly2.n);
+    let n = poly1.n;
+
+    let poly1: Vec<u128> = poly1.coeffs.iter().map(|c| c.0 as u128).collect();
+    let poly2: Vec<u128> = poly2.coeffs.iter().map(|c| c.0 as u128).collect();
+    let mut result: Vec<u128> = vec![0; (n * 2) - 1];
+    for i in 0..n {
+        for j in 0..n {
             result[i + j] = result[i + j] + poly1[i] * poly2[j];
         }
     }
 
-    // apply mod (X^N + 1))
-    modulus_u128::<N>(&mut result);
+    // apply mod (X^n + 1))
+    modulus_u128(n, &mut result);
 
-    Tn(array::from_fn(|i| T64(result[i] as u64)))
+    Tn {
+        n,
+        // coeffs: array::from_fn(|i| T64(result[i] as u64)),
+        coeffs: result.iter().map(|r_i| T64(*r_i as u64)).collect(),
+    }
 }
-fn modulus_u128<const N: usize>(p: &mut Vec<u128>) {
-    if p.len() < N {
+fn modulus_u128(n: usize, p: &mut Vec<u128>) {
+    if p.len() < n {
         return;
     }
-    for i in N..p.len() {
-        // p[i - N] = p[i - N].clone() - p[i].clone();
-        p[i - N] = p[i - N].wrapping_sub(p[i]);
+    for i in n..p.len() {
+        // p[i - n] = p[i - n].clone() - p[i].clone();
+        p[i - n] = p[i - n].wrapping_sub(p[i]);
         p[i] = 0;
     }
-    p.truncate(N);
+    p.truncate(n);
 }
 
-impl<const N: usize> Mul<T64> for Tn<N> {
+impl Mul<T64> for Tn {
     type Output = Self;
     fn mul(self, s: T64) -> Self {
-        Self(array::from_fn(|i| self.0[i] * s))
+        Self {
+            n: self.n,
+            // coeffs: array::from_fn(|i| self.coeffs[i] * s),
+            coeffs: self.coeffs.iter().map(|c_i| *c_i * s).collect(),
+        }
     }
 }
 // mul by u64
-impl<const N: usize> Mul<u64> for Tn<N> {
+impl Mul<u64> for Tn {
     type Output = Self;
     fn mul(self, s: u64) -> Self {
-        Self(array::from_fn(|i| self.0[i] * s))
+        // Self(array::from_fn(|i| self.0[i] * s))
+        Tn {
+            n: self.n,
+            coeffs: self.coeffs.iter().map(|c_i| *c_i * s).collect(),
+        }
     }
 }
-impl<const N: usize> Mul<&u64> for &Tn<N> {
-    type Output = Tn<N>;
+impl Mul<&u64> for &Tn {
+    type Output = Tn;
     fn mul(self, s: &u64) -> Self::Output {
-        Tn::<N>(array::from_fn(|i| self.0[i] * *s))
+        // Tn::<N>(array::from_fn(|i| self.0[i] * *s))
+        Self {
+            n: self.n,
+            coeffs: self.coeffs.iter().map(|c_i| c_i * s).collect(),
+        }
     }
 }
 
@@ -256,8 +337,9 @@ mod tests {
 
     #[test]
     fn test_left_rotate() {
-        const N: usize = 4;
-        let f = Tn::<N>::from_vec(
+        let n: usize = 4;
+        let f = Tn::from_vec(
+            n,
             vec![2i64, 3, -4, -1]
                 .iter()
                 .map(|c| T64(*c as u64))
@@ -267,7 +349,8 @@ mod tests {
         // expect f*x^-3 == -1 -2x -3x^2 +4x^3
         assert_eq!(
             f.left_rotate(3),
-            Tn::<N>::from_vec(
+            Tn::from_vec(
+                n,
                 vec![-1i64, -2, -3, 4]
                     .iter()
                     .map(|c| T64(*c as u64))
@@ -277,7 +360,8 @@ mod tests {
         // expect f*x^-1 == 3 -4x -1x^2 -2x^3
         assert_eq!(
             f.left_rotate(1),
-            Tn::<N>::from_vec(
+            Tn::from_vec(
+                n,
                 vec![3i64, -4, -1, -2]
                     .iter()
                     .map(|c| T64(*c as u64))

--- a/arith/src/ring_torus.rs
+++ b/arith/src/ring_torus.rs
@@ -22,17 +22,12 @@ use crate::{
 /// 𝕋, where Q=2^64.
 #[derive(Clone, Debug)]
 pub struct Tn {
-    // pub n: usize,
     pub param: RingParam,
     pub coeffs: Vec<T64>,
 }
 
 impl Ring for Tn {
     type C = T64;
-    // type Param = usize; // n
-
-    // const Q: u64 = u64::MAX; // WIP
-    // const N: usize = N;
 
     fn param(&self) -> RingParam {
         RingParam {
@@ -58,7 +53,6 @@ impl Ring for Tn {
                 .take(param.n)
                 .collect(),
         }
-        // Self(array::from_fn(|_| T64::rand(&mut rng, &dist)))
     }
 
     fn from_vec(param: &RingParam, coeffs: Vec<Self::C>) -> Self {
@@ -160,7 +154,6 @@ impl Add<Tn> for Tn {
     type Output = Self;
 
     fn add(self, rhs: Self) -> Self {
-        // Self(array::from_fn(|i| self.0[i] + rhs.0[i]))
         assert_eq!(self.param, rhs.param);
         Self {
             param: self.param,
@@ -174,7 +167,6 @@ impl Add<&Tn> for &Tn {
     type Output = Tn;
 
     fn add(self, rhs: &Tn) -> Self::Output {
-        // Tn(array::from_fn(|i| self.0[i] + rhs.0[i]))
         assert_eq!(self.param, rhs.param);
         Tn {
             param: self.param,
@@ -198,11 +190,6 @@ impl Sum<Tn> for Tn {
     where
         I: Iterator<Item = Self>,
     {
-        // let mut acc = Tn::<N>::zero();
-        // for e in iter {
-        //     acc += e;
-        // }
-        // acc
         let first = iter.next().unwrap();
         iter.fold(first, |acc, x| acc + x)
     }
@@ -225,7 +212,6 @@ impl Sub<&Tn> for &Tn {
     type Output = Tn;
 
     fn sub(self, rhs: &Tn) -> Self::Output {
-        // Tn(array::from_fn(|i| self.0[i] - rhs.0[i]))
         assert_eq!(self.param, rhs.param);
         Tn {
             param: self.param,
@@ -238,9 +224,6 @@ impl Sub<&Tn> for &Tn {
 
 impl SubAssign for Tn {
     fn sub_assign(&mut self, rhs: Self) {
-        // for i in 0..N {
-        //     self.0[i] -= rhs.0[i];
-        // }
         assert_eq!(self.param, rhs.param);
         for i in 0..self.param.n {
             self.coeffs[i] -= rhs.coeffs[i];
@@ -252,7 +235,6 @@ impl Neg for Tn {
     type Output = Self;
 
     fn neg(self) -> Self::Output {
-        // Tn(array::from_fn(|i| -self.0[i]))
         Self {
             param: self.param,
             coeffs: self.coeffs.iter().map(|c_i| -*c_i).collect(),
@@ -300,7 +282,6 @@ fn naive_poly_mul(poly1: &Tn, poly2: &Tn) -> Tn {
 
     Tn {
         param,
-        // coeffs: array::from_fn(|i| T64(result[i] as u64)),
         coeffs: result.iter().map(|r_i| T64(*r_i as u64)).collect(),
     }
 }
@@ -321,7 +302,6 @@ impl Mul<T64> for Tn {
     fn mul(self, s: T64) -> Self {
         Self {
             param: self.param,
-            // coeffs: array::from_fn(|i| self.coeffs[i] * s),
             coeffs: self.coeffs.iter().map(|c_i| *c_i * s).collect(),
         }
     }
@@ -330,7 +310,6 @@ impl Mul<T64> for Tn {
 impl Mul<u64> for Tn {
     type Output = Self;
     fn mul(self, s: u64) -> Self {
-        // Self(array::from_fn(|i| self.0[i] * s))
         Tn {
             param: self.param,
             coeffs: self.coeffs.iter().map(|c_i| *c_i * s).collect(),
@@ -340,7 +319,6 @@ impl Mul<u64> for Tn {
 impl Mul<&u64> for &Tn {
     type Output = Tn;
     fn mul(self, s: &u64) -> Self::Output {
-        // Tn::<N>(array::from_fn(|i| self.0[i] * *s))
         Tn {
             param: self.param,
             coeffs: self.coeffs.iter().map(|c_i| c_i * s).collect(),

--- a/arith/src/ring_torus.rs
+++ b/arith/src/ring_torus.rs
@@ -9,7 +9,6 @@
 
 use itertools::zip_eq;
 use rand::{distributions::Distribution, Rng};
-use std::array;
 use std::iter::Sum;
 use std::ops::{Add, AddAssign, Mul, Neg, Sub, SubAssign};
 

--- a/arith/src/torus.rs
+++ b/arith/src/torus.rs
@@ -16,10 +16,6 @@ pub struct T64(pub u64);
 // `Tn<1>`.
 impl Ring for T64 {
     type C = T64;
-    // type Param = ();
-
-    // const Q: u64 = u64::MAX; // WIP
-    // const N: usize = 1;
 
     fn param(&self) -> RingParam {
         RingParam {
@@ -45,13 +41,13 @@ impl Ring for T64 {
     // TODO rm beta & l from inputs, make it always beta=2,l=64.
     /// Note: only beta=2 and l=64 is supported.
     fn decompose(&self, beta: u32, l: u32) -> Vec<Self> {
-        assert_eq!(beta, 2u32); // only beta=2 supported
-                                // assert_eq!(l, 64u32); // only l=64 supported
+        assert_eq!(beta, 2u32, "only beta=2 supported");
+        // assert_eq!(l, 64u32, "only l=64 supported");
 
         // (0..64)
-        (0..l)
+        (0..l as u64)
             .rev()
-            .map(|i| T64(((self.0 >> i) & 1) as u64))
+            .map(|i| T64((self.0 >> i) & 1))
             .collect()
     }
     fn remodule(&self, p: u64) -> T64 {

--- a/arith/src/torus.rs
+++ b/arith/src/torus.rs
@@ -4,7 +4,7 @@ use std::{
     ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign},
 };
 
-use crate::ring::Ring;
+use crate::ring::{Ring, RingParam};
 
 /// Let 𝕋 = ℝ/ℤ, where 𝕋 is a ℤ-module, with homogeneous external product.
 /// Let 𝕋q
@@ -21,20 +21,23 @@ impl Ring for T64 {
     // const Q: u64 = u64::MAX; // WIP
     // const N: usize = 1;
 
-    fn param(&self) -> Self::Param {
-        ()
+    fn param(&self) -> RingParam {
+        RingParam {
+            q: u64::MAX, // WIP
+            n: 1,
+        }
     }
     fn coeffs(&self) -> Vec<T64> {
         vec![self.clone()]
     }
-    fn zero(_: ()) -> Self {
+    fn zero(_: &RingParam) -> Self {
         Self(0u64)
     }
-    fn rand(mut rng: impl Rng, dist: impl Distribution<f64>, _: ()) -> Self {
+    fn rand(mut rng: impl Rng, dist: impl Distribution<f64>, _: &RingParam) -> Self {
         let r: f64 = dist.sample(&mut rng);
         Self(r.round() as u64)
     }
-    fn from_vec(_n: (), coeffs: Vec<Self::C>) -> Self {
+    fn from_vec(_n: &RingParam, coeffs: Vec<Self::C>) -> Self {
         assert_eq!(coeffs.len(), 1);
         coeffs[0]
     }
@@ -178,9 +181,13 @@ mod tests {
         let d = x.decompose(beta, l);
         assert_eq!(recompose(d), T64(u64::MAX - 1));
 
+        let param = RingParam {
+            q: u64::MAX, // WIP
+            n: 1,
+        };
         let mut rng = rand::thread_rng();
         for _ in 0..1000 {
-            let x = T64::rand(&mut rng, Standard, ());
+            let x = T64::rand(&mut rng, Standard, &param);
             let d = x.decompose(beta, l);
             assert_eq!(recompose(d), x);
         }

--- a/arith/src/torus.rs
+++ b/arith/src/torus.rs
@@ -16,20 +16,22 @@ pub struct T64(pub u64);
 // `Tn<1>`.
 impl Ring for T64 {
     type C = T64;
-    const Q: u64 = u64::MAX; // WIP
-    const N: usize = 1;
+    type Params = ();
+
+    // const Q: u64 = u64::MAX; // WIP
+    // const N: usize = 1;
 
     fn coeffs(&self) -> Vec<T64> {
         vec![self.clone()]
     }
-    fn zero() -> Self {
+    fn zero(_: ()) -> Self {
         Self(0u64)
     }
-    fn rand(mut rng: impl Rng, dist: impl Distribution<f64>) -> Self {
+    fn rand(mut rng: impl Rng, dist: impl Distribution<f64>, _: ()) -> Self {
         let r: f64 = dist.sample(&mut rng);
         Self(r.round() as u64)
     }
-    fn from_vec(coeffs: Vec<Self::C>) -> Self {
+    fn from_vec(_n: (), coeffs: Vec<Self::C>) -> Self {
         assert_eq!(coeffs.len(), 1);
         coeffs[0]
     }
@@ -46,18 +48,18 @@ impl Ring for T64 {
             .map(|i| T64(((self.0 >> i) & 1) as u64))
             .collect()
     }
-    fn remodule<const P: u64>(&self) -> T64 {
+    fn remodule(&self, p: u64) -> T64 {
         todo!()
     }
 
     // modulus switch from Q to Q2: self * Q2/Q
-    fn mod_switch<const Q2: u64>(&self) -> T64 {
+    fn mod_switch(&self, q2: u64) -> T64 {
         // for the moment we assume Q|Q2, since Q=2^64, check that Q2 is a power
         // of two:
-        assert!(Q2.is_power_of_two());
+        assert!(q2.is_power_of_two());
         // since Q=2^64, dividing Q2/Q is equivalent to dividing 2^log2(Q2)/2^64
         // which would be like right-shifting 64-log2(Q2).
-        let log2_q2 = 63 - Q2.leading_zeros();
+        let log2_q2 = 63 - q2.leading_zeros();
         T64(self.0 >> (64 - log2_q2))
     }
 
@@ -175,7 +177,7 @@ mod tests {
 
         let mut rng = rand::thread_rng();
         for _ in 0..1000 {
-            let x = T64::rand(&mut rng, Standard);
+            let x = T64::rand(&mut rng, Standard, ());
             let d = x.decompose(beta, l);
             assert_eq!(recompose(d), x);
         }

--- a/arith/src/torus.rs
+++ b/arith/src/torus.rs
@@ -16,11 +16,14 @@ pub struct T64(pub u64);
 // `Tn<1>`.
 impl Ring for T64 {
     type C = T64;
-    type Params = ();
+    // type Param = ();
 
     // const Q: u64 = u64::MAX; // WIP
     // const N: usize = 1;
 
+    fn param(&self) -> Self::Param {
+        ()
+    }
     fn coeffs(&self) -> Vec<T64> {
         vec![self.clone()]
     }

--- a/arith/src/tuple_ring.rs
+++ b/arith/src/tuple_ring.rs
@@ -11,7 +11,7 @@ use std::{
     ops::{Add, Mul, Neg, Sub},
 };
 
-use crate::Ring;
+use crate::{Ring, RingParam};
 
 /// Tuple of K Ring (Rq) elements. We use Vec<R> to allocate it in the heap,
 /// since if using a fixed-size array it would overflow the stack.
@@ -28,7 +28,7 @@ impl<R: Ring> TR<R> {
         assert_eq!(r.len(), k);
         Self { k, r }
     }
-    pub fn zero(k: usize, r_params: R::Params) -> Self {
+    pub fn zero(k: usize, r_params: &RingParam) -> Self {
         Self {
             k,
             r: (0..k).into_iter().map(|_| R::zero(r_params)).collect(),
@@ -38,7 +38,7 @@ impl<R: Ring> TR<R> {
         mut rng: impl Rng,
         dist: impl Distribution<f64>,
         k: usize,
-        r_params: R::Params,
+        r_params: &RingParam,
     ) -> Self {
         Self {
             k,

--- a/arith/src/tuple_ring.rs
+++ b/arith/src/tuple_ring.rs
@@ -113,7 +113,7 @@ impl<R: Ring> Neg for TR<R> {
     fn neg(self) -> Self::Output {
         Self {
             k: self.k,
-            r: self.r.iter().map(|e_i| -*e_i).collect(),
+            r: self.r.iter().map(|e_i| -e_i.clone()).collect(),
         }
     }
 }

--- a/arith/src/tuple_ring.rs
+++ b/arith/src/tuple_ring.rs
@@ -1,15 +1,9 @@
 //! This file implements the struct for an Tuple of Ring Rq elements and its
 //! operations, which are performed element-wise.
 
-use anyhow::Result;
 use itertools::zip_eq;
 use rand::{distributions::Distribution, Rng};
-use rand_distr::{Normal, Uniform};
-use std::iter::Sum;
-use std::{
-    array,
-    ops::{Add, Mul, Neg, Sub},
-};
+use std::ops::{Add, Mul, Neg, Sub};
 
 use crate::{Ring, RingParam};
 
@@ -28,23 +22,23 @@ impl<R: Ring> TR<R> {
         assert_eq!(r.len(), k);
         Self { k, r }
     }
-    pub fn zero(k: usize, r_params: &RingParam) -> Self {
+    pub fn zero(k: usize, r_param: &RingParam) -> Self {
         Self {
             k,
-            r: (0..k).into_iter().map(|_| R::zero(r_params)).collect(),
+            r: (0..k).into_iter().map(|_| R::zero(r_param)).collect(),
         }
     }
     pub fn rand(
         mut rng: impl Rng,
         dist: impl Distribution<f64>,
         k: usize,
-        r_params: &RingParam,
+        r_param: &RingParam,
     ) -> Self {
         Self {
             k,
             r: (0..k)
                 .into_iter()
-                .map(|_| R::rand(&mut rng, &dist, r_params))
+                .map(|_| R::rand(&mut rng, &dist, r_param))
                 .collect(),
         }
     }

--- a/arith/src/zq.rs
+++ b/arith/src/zq.rs
@@ -9,13 +9,6 @@ pub struct Zq {
     pub v: u64,
 }
 
-// WIP
-// impl<const Q: u64> From<Vec<u64>> for Vec<Zq<Q>> {
-//     fn from(v: Vec<u64>) -> Self {
-//         v.into_iter().map(Zq::new).collect()
-//     }
-// }
-
 pub(crate) fn modulus_u64(q: u64, e: u64) -> u64 {
     (e % q + q) % q
 }
@@ -24,7 +17,6 @@ impl Zq {
         // TODO WIP
         let r: f64 = dist.sample(&mut rng);
         Self::from_f64(q, r)
-        // Self::from_u64(r.round() as u64)
     }
     pub fn from_u64(q: u64, v: u64) -> Self {
         if v >= q {
@@ -81,7 +73,7 @@ impl Zq {
         // for rem != Self(0) {
         while rem != Self::zero(self.q) {
             // if odd
-            // TODO use a more readible expression
+            // TODO use a more readeable expression
             if 1 - ((rem.v & 1) << 1) as i64 == -1 {
                 res = res * exp;
             }

--- a/arith/src/zq.rs
+++ b/arith/src/zq.rs
@@ -1,5 +1,4 @@
 use rand::{distributions::Distribution, Rng};
-use std::borrow::Borrow;
 use std::fmt;
 use std::ops::{Add, AddAssign, Div, Mul, Neg, Sub, SubAssign};
 

--- a/bfv/src/lib.rs
+++ b/bfv/src/lib.rs
@@ -17,37 +17,38 @@ use arith::{Ring, Rq, R};
 const ERR_SIGMA: f64 = 3.2;
 
 #[derive(Clone, Debug)]
-pub struct SecretKey<const Q: u64, const N: usize>(Rq<Q, N>);
+pub struct SecretKey(Rq);
 
 #[derive(Clone, Debug)]
-pub struct PublicKey<const Q: u64, const N: usize>(Rq<Q, N>, Rq<Q, N>);
+pub struct PublicKey(Rq, Rq);
 
 /// Relinearization key
 #[derive(Clone, Debug)]
-pub struct RLK<const PQ: u64, const N: usize>(Rq<PQ, N>, Rq<PQ, N>);
+pub struct RLK(Rq, Rq);
 
 // RLWE ciphertext
 #[derive(Clone, Debug)]
-pub struct RLWE<const Q: u64, const N: usize>(Rq<Q, N>, Rq<Q, N>);
+pub struct RLWE(Rq, Rq);
 
-impl<const Q: u64, const N: usize> RLWE<Q, N> {
+impl RLWE {
     fn add(lhs: Self, rhs: Self) -> Self {
-        RLWE::<Q, N>(lhs.0 + rhs.0, lhs.1 + rhs.1)
+        RLWE(lhs.0 + rhs.0, lhs.1 + rhs.1)
     }
-    pub fn remodule<const P: u64>(&self) -> RLWE<P, N> {
-        let x = self.0.remodule::<P>();
-        let y = self.1.remodule::<P>();
-        RLWE::<P, N>(x, y)
+    pub fn remodule(&self, p: u64) -> RLWE {
+        let x = self.0.remodule(p);
+        let y = self.1.remodule(p);
+        RLWE(x, y)
     }
 
-    fn tensor<const PQ: u64, const T: u64>(a: &Self, b: &Self) -> (Rq<Q, N>, Rq<Q, N>, Rq<Q, N>) {
+    fn tensor(t: u64, a: &Self, b: &Self) -> (Rq, Rq, Rq) {
+        let (q, n) = (a.0.q, a.0.n);
         // expand Q->PQ // TODO rm
 
         // get the coefficients in Z, ie. interpret a,b \in R (instead of R_q)
-        let a0: R<N> = a.0.to_r();
-        let a1: R<N> = a.1.to_r();
-        let b0: R<N> = b.0.to_r();
-        let b1: R<N> = b.1.to_r();
+        let a0: R = a.0.clone().to_r(); // TODO rm clone()
+        let a1: R = a.1.clone().to_r();
+        let b0: R = b.0.clone().to_r();
+        let b1: R = b.1.clone().to_r();
 
         // tensor (\in R) (2021-204 p.9)
         // NOTE: here can use *, but at first versions want to make it explicit
@@ -60,44 +61,50 @@ impl<const Q: u64, const N: usize> RLWE<Q, N> {
         let c2: Vec<i64> = naive_mul(&a1, &b1);
 
         // scale down, then reduce module Q, so result is \in R_q
-        let c0: Rq<Q, N> = arith::ring_n::mul_div_round::<Q, N>(c0, T, Q);
-        let c1: Rq<Q, N> = arith::ring_n::mul_div_round::<Q, N>(c1, T, Q);
-        let c2: Rq<Q, N> = arith::ring_n::mul_div_round::<Q, N>(c2, T, Q);
+        let c0: Rq = arith::ring_n::mul_div_round(q, n, c0, t, q);
+        let c1: Rq = arith::ring_n::mul_div_round(q, n, c1, t, q);
+        let c2: Rq = arith::ring_n::mul_div_round(q, n, c2, t, q);
 
         (c0, c1, c2)
     }
     /// ciphertext multiplication
-    fn mul<const PQ: u64, const T: u64>(rlk: &RLK<PQ, N>, a: &Self, b: &Self) -> Self {
-        let (c0, c1, c2) = Self::tensor::<PQ, T>(a, b);
-        BFV::<Q, N, T>::relinearize_204::<PQ>(&rlk, &c0, &c1, &c2)
+    fn mul(t: u64, rlk: &RLK, a: &Self, b: &Self) -> Self {
+        let (c0, c1, c2) = Self::tensor(t, a, b);
+        BFV::relinearize_204(&rlk, &c0, &c1, &c2)
     }
 }
 // naive mul in the ring Rq, reusing the ring_n::naive_mul and then applying mod(X^N +1)
-fn tmp_naive_mul<const Q: u64, const N: usize>(a: Rq<Q, N>, b: Rq<Q, N>) -> Rq<Q, N> {
-    Rq::<Q, N>::from_vec_i64(arith::ring_n::naive_mul(&a.to_r(), &b.to_r()))
+fn tmp_naive_mul(a: Rq, b: Rq) -> Rq {
+    Rq::from_vec_i64(a.q, a.n, arith::ring_n::naive_mul(&a.to_r(), &b.to_r()))
 }
 
-impl<const Q: u64, const N: usize> ops::Add<RLWE<Q, N>> for RLWE<Q, N> {
+impl ops::Add<RLWE> for RLWE {
     type Output = Self;
     fn add(self, rhs: Self) -> Self {
         Self::add(self, rhs)
     }
 }
 
-impl<const Q: u64, const N: usize, const T: u64> ops::Add<&Rq<T, N>> for &RLWE<Q, N> {
-    type Output = RLWE<Q, N>;
-    fn add(self, rhs: &Rq<T, N>) -> Self::Output {
-        BFV::<Q, N, T>::add_const(self, rhs)
+impl ops::Add<&Rq> for &RLWE {
+    type Output = RLWE;
+    fn add(self, rhs: &Rq) -> Self::Output {
+        BFV::add_const(self, rhs)
     }
 }
 
-pub struct BFV<const Q: u64, const N: usize, const T: u64> {}
+pub struct Params {
+    q: u64,
+    n: usize,
+    t: u64,
+    p: u64,
+}
+pub struct BFV {}
 
-impl<const Q: u64, const N: usize, const T: u64> BFV<Q, N, T> {
-    const DELTA: u64 = Q / T; // floor
+impl BFV {
+    // const DELTA: u64 = Q / T; // floor
 
     /// generate a new key pair (privK, pubK)
-    pub fn new_key(mut rng: impl Rng) -> Result<(SecretKey<Q, N>, PublicKey<Q, N>)> {
+    pub fn new_key(mut rng: impl Rng, params: &Params) -> Result<(SecretKey, PublicKey)> {
         // WIP: review probabilities
 
         // let Xi_key = Uniform::new(-1_f64, 1_f64);
@@ -105,114 +112,135 @@ impl<const Q: u64, const N: usize, const T: u64> BFV<Q, N, T> {
         let Xi_err = Normal::new(0_f64, ERR_SIGMA)?;
 
         // secret key
-        // let mut s = Rq::<Q, N>::rand_f64(&mut rng, Xi_key)?;
-        let mut s = Rq::<Q, N>::rand_u64(&mut rng, Xi_key)?;
+        // let mut s = Rq::rand_f64(&mut rng, Xi_key)?;
+        let mut s = Rq::rand_u64(&mut rng, Xi_key, params.q, params.n)?;
         // since s is going to be multiplied by other Rq elements, already
         // compute its NTT
         s.compute_evals();
 
         // pk = (-a * s + e, a)
-        let a = Rq::<Q, N>::rand_u64(&mut rng, Uniform::new(0_u64, Q))?;
-        let e = Rq::<Q, N>::rand_f64(&mut rng, Xi_err)?;
-        let pk: PublicKey<Q, N> = PublicKey((&(-a) * &s) + e, a.clone());
+        let a = Rq::rand_u64(&mut rng, Uniform::new(0_u64, params.q), params.q, params.n)?;
+        let e = Rq::rand_f64(&mut rng, Xi_err, params.q, params.n)?;
+        let pk: PublicKey = PublicKey(&(&(-a.clone()) * &s) + &e, a.clone()); // TODO rm clones
         Ok((SecretKey(s), pk))
     }
 
-    pub fn encrypt(mut rng: impl Rng, pk: &PublicKey<Q, N>, m: &Rq<T, N>) -> Result<RLWE<Q, N>> {
+    // note: m is modulus t
+    pub fn encrypt(mut rng: impl Rng, params: &Params, pk: &PublicKey, m: &Rq) -> Result<RLWE> {
+        // assert params & inputs
+        debug_assert_eq!(params.q, pk.0.q);
+        debug_assert_eq!(params.n, pk.0.n);
+        debug_assert_eq!(params.t, m.q);
+        debug_assert_eq!(params.n, m.n);
+
         let Xi_key = Uniform::new(-1_f64, 1_f64);
         // let Xi_key = Uniform::new(0_u64, 2_u64);
         let Xi_err = Normal::new(0_f64, ERR_SIGMA)?;
 
-        let u = Rq::<Q, N>::rand_f64(&mut rng, Xi_key)?;
-        // let u = Rq::<Q, N>::rand_u64(&mut rng, Xi_key)?;
-        let e_1 = Rq::<Q, N>::rand_f64(&mut rng, Xi_err)?;
-        let e_2 = Rq::<Q, N>::rand_f64(&mut rng, Xi_err)?;
+        let u = Rq::rand_f64(&mut rng, Xi_key, params.q, params.n)?;
+        // let u = Rq::rand_u64(&mut rng, Xi_key)?;
+        let e_1 = Rq::rand_f64(&mut rng, Xi_err, params.q, params.n)?;
+        let e_2 = Rq::rand_f64(&mut rng, Xi_err, params.q, params.n)?;
 
         // migrate m's coeffs to the bigger modulus Q (from T)
-        let m = m.remodule::<Q>();
-        let c0 = &pk.0 * &u + e_1 + m * Self::DELTA;
+        let m = m.remodule(params.q);
+        let c0 = &pk.0 * &u + e_1 + m * (params.q / params.t); // floor(q/t)=DELTA
         let c1 = &pk.1 * &u + e_2;
-        Ok(RLWE::<Q, N>(c0, c1))
+        Ok(RLWE(c0, c1))
     }
 
-    pub fn decrypt(sk: &SecretKey<Q, N>, c: &RLWE<Q, N>) -> Rq<T, N> {
-        let cs = c.0 + c.1 * sk.0; // done in mod q
+    pub fn decrypt(params: &Params, sk: &SecretKey, c: &RLWE) -> Rq {
+        debug_assert_eq!(params.q, sk.0.q);
+        debug_assert_eq!(params.n, sk.0.n);
+        debug_assert_eq!(params.q, c.0.q);
+        debug_assert_eq!(params.n, c.0.n);
+
+        let cs: Rq = &c.0 + &(&c.1 * &sk.0); // done in mod q
 
         // same but with naive_mul:
         // let c1s = arith::ring_n::naive_mul(&c.1.to_r(), &sk.0.to_r());
-        // let c1s = Rq::<Q, N>::from_vec_i64(c1s);
+        // let c1s = Rq::from_vec_i64(c1s);
         // let cs = c.0 + c1s;
 
-        let r: Rq<Q, N> = cs.mul_div_round(T, Q);
-        r.remodule::<T>()
+        let r: Rq = cs.mul_div_round(params.t, params.q);
+        r.remodule(params.t)
     }
 
-    fn add_const(c: &RLWE<Q, N>, m: &Rq<T, N>) -> RLWE<Q, N> {
+    fn add_const(c: &RLWE, m: &Rq) -> RLWE {
+        let q = c.0.q;
+        let t = m.q;
+
         // assuming T<Q, move m from Zq<T> to Zq<Q>
-        let m = m.remodule::<Q>();
-        RLWE::<Q, N>(c.0 + m * Self::DELTA, c.1)
+        let m = m.remodule(c.0.q);
+        // TODO rm clones
+        RLWE(c.0.clone() + m * (q / t), c.1.clone()) // floor(q/t)=DELTA
     }
-    fn mul_const<const PQ: u64>(rlk: &RLK<PQ, N>, c: &RLWE<Q, N>, m: &Rq<T, N>) -> RLWE<Q, N> {
+    fn mul_const(rlk: &RLK, c: &RLWE, m: &Rq) -> RLWE {
+        // let pq = rlk.0.q;
+        let q = c.0.q;
+        let n = c.0.n;
+        let t = m.q;
+
         // assuming T<Q, move m from Zq<T> to Zq<Q>
-        let m = m.remodule::<Q>();
+        let m = m.remodule(q);
 
         // encrypt m*Delta without noise, and then perform normal ciphertext multiplication
-        let md = RLWE::<Q, N>(m * Self::DELTA, Rq::zero());
-        RLWE::<Q, N>::mul::<PQ, T>(&rlk, &c, &md)
+        let md = RLWE(m * (q / t), Rq::zero((q, n))); // floor(q/t)=DELTA
+        RLWE::mul(t, &rlk, &c, &md)
     }
 
-    fn rlk_key<const PQ: u64>(mut rng: impl Rng, s: &SecretKey<Q, N>) -> Result<RLK<PQ, N>> {
+    fn rlk_key(mut rng: impl Rng, params: &Params, s: &SecretKey) -> Result<RLK> {
+        let pq = params.p * params.q;
+        let n = params.n;
+
         // TODO review using Xi' instead of Xi
         let Xi_err = Normal::new(0_f64, ERR_SIGMA)?;
         // let Xi_err = Normal::new(0_f64, 0.0)?;
-        let s = s.0.remodule::<PQ>();
-        let a = Rq::<PQ, N>::rand_u64(&mut rng, Uniform::new(0_u64, PQ))?;
-        let e = Rq::<PQ, N>::rand_f64(&mut rng, Xi_err)?;
-
-        let P = PQ / Q;
+        let s = s.0.remodule(pq);
+        let a = Rq::rand_u64(&mut rng, Uniform::new(0_u64, pq), pq, n)?;
+        let e = Rq::rand_f64(&mut rng, Xi_err, pq, n)?;
 
         // let rlk: RLK<PQ, N> = RLK::<PQ, N>(-(&a * &s + e) + (s * s) * P, a.clone());
-        let rlk: RLK<PQ, N> = RLK::<PQ, N>(
-            -(tmp_naive_mul(a, s) + e) + tmp_naive_mul(s, s) * P,
+        // TODO rm clones
+        let rlk: RLK = RLK(
+            -(tmp_naive_mul(a.clone(), s.clone()) + e)
+                + tmp_naive_mul(s.clone(), s.clone()) * params.p,
             a.clone(),
         );
 
         Ok(rlk)
     }
 
-    fn relinearize<const PQ: u64>(
-        rlk: &RLK<PQ, N>,
-        c0: &Rq<Q, N>,
-        c1: &Rq<Q, N>,
-        c2: &Rq<Q, N>,
-    ) -> RLWE<Q, N> {
-        let P = PQ / Q;
+    fn relinearize(rlk: &RLK, c0: &Rq, c1: &Rq, c2: &Rq) -> RLWE {
+        let pq = rlk.0.q;
+        let q = c0.q;
+        let p = pq / q;
+        let n = c0.n;
 
-        let c2rlk0: Vec<f64> = (c2.to_r() * rlk.0.to_r())
+        let c2rlk0: Vec<f64> = (c2.clone().to_r() * rlk.0.clone().to_r())
             .coeffs()
             .iter()
-            .map(|e| (*e as f64 / P as f64).round())
+            .map(|e| (*e as f64 / p as f64).round())
             .collect();
 
-        let c2rlk1: Vec<f64> = (c2.to_r() * rlk.1.to_r())
+        let c2rlk1: Vec<f64> = (c2.clone().to_r() * rlk.1.clone().to_r()) // TODO rm clones
             .coeffs()
             .iter()
-            .map(|e| (*e as f64 / P as f64).round())
+            .map(|e| (*e as f64 / p as f64).round())
             .collect();
 
-        let r0 = Rq::<Q, N>::from_vec_f64(c2rlk0);
-        let r1 = Rq::<Q, N>::from_vec_f64(c2rlk1);
+        let r0 = Rq::from_vec_f64(q, n, c2rlk0);
+        let r1 = Rq::from_vec_f64(q, n, c2rlk1);
 
-        let res = RLWE::<Q, N>(c0 + &r0, c1 + &r1);
+        let res = RLWE(c0 + &r0, c1 + &r1);
         res
     }
-    fn relinearize_204<const PQ: u64>(
-        rlk: &RLK<PQ, N>,
-        c0: &Rq<Q, N>,
-        c1: &Rq<Q, N>,
-        c2: &Rq<Q, N>,
-    ) -> RLWE<Q, N> {
-        let P = PQ / Q;
+    fn relinearize_204(rlk: &RLK, c0: &Rq, c1: &Rq, c2: &Rq) -> RLWE {
+        let pq = rlk.0.q;
+        let q = c0.q;
+        let p = pq / q;
+        let n = c0.n;
+        // TODO (in debug) check that all Ns match
 
         // let c2rlk0: Rq<PQ, N> = c2.remodule::<PQ>() * rlk.0.remodule::<PQ>();
         // let c2rlk1: Rq<PQ, N> = c2.remodule::<PQ>() * rlk.1.remodule::<PQ>();
@@ -220,12 +248,12 @@ impl<const Q: u64, const N: usize, const T: u64> BFV<Q, N, T> {
         // let r1: Rq<Q, N> = c2rlk1.mul_div_round(1, P).remodule::<Q>();
 
         use arith::ring_n::naive_mul;
-        let c2rlk0: Vec<i64> = naive_mul(&c2.to_r(), &rlk.0.to_r());
-        let c2rlk1: Vec<i64> = naive_mul(&c2.to_r(), &rlk.1.to_r());
-        let r0: Rq<Q, N> = arith::ring_n::mul_div_round::<Q, N>(c2rlk0, 1, P);
-        let r1: Rq<Q, N> = arith::ring_n::mul_div_round::<Q, N>(c2rlk1, 1, P);
+        let c2rlk0: Vec<i64> = naive_mul(&c2.clone().to_r(), &rlk.0.clone().to_r()); // TODO rm clones
+        let c2rlk1: Vec<i64> = naive_mul(&c2.clone().to_r(), &rlk.1.clone().to_r());
+        let r0: Rq = arith::ring_n::mul_div_round(q, n, c2rlk0, 1, p);
+        let r1: Rq = arith::ring_n::mul_div_round(q, n, c2rlk1, 1, p);
 
-        let res = RLWE::<Q, N>(c0 + &r0, c1 + &r1);
+        let res = RLWE(c0 + &r0, c1 + &r1);
         res
     }
 }
@@ -239,21 +267,23 @@ mod tests {
 
     #[test]
     fn test_encrypt_decrypt() -> Result<()> {
-        const Q: u64 = 2u64.pow(16) + 1;
-        const N: usize = 512;
-        const T: u64 = 32; // plaintext modulus
-        type S = BFV<Q, N, T>;
+        let params = Params {
+            q: 2u64.pow(16) + 1, // q prime, and 2^q + 1 shape
+            n: 512,
+            t: 32, // plaintext modulus
+            p: 0,  // unused in this test
+        };
 
         let mut rng = rand::thread_rng();
 
         for _ in 0..100 {
-            let (sk, pk) = S::new_key(&mut rng)?;
+            let (sk, pk) = BFV::new_key(&mut rng, &params)?;
 
-            let msg_dist = Uniform::new(0_u64, T);
-            let m = Rq::<T, N>::rand_u64(&mut rng, msg_dist)?;
+            let msg_dist = Uniform::new(0_u64, params.t);
+            let m = Rq::rand_u64(&mut rng, msg_dist, params.t, params.n)?;
 
-            let c = S::encrypt(&mut rng, &pk, &m)?;
-            let m_recovered = S::decrypt(&sk, &c);
+            let c = BFV::encrypt(&mut rng, &params, &pk, &m)?;
+            let m_recovered = BFV::decrypt(&params, &sk, &c);
 
             assert_eq!(m, m_recovered);
         }
@@ -263,26 +293,28 @@ mod tests {
 
     #[test]
     fn test_addition() -> Result<()> {
-        const Q: u64 = 2u64.pow(16) + 1;
-        const N: usize = 128;
-        const T: u64 = 32; // plaintext modulus
-        type S = BFV<Q, N, T>;
+        let params = Params {
+            q: 2u64.pow(16) + 1, // q prime, and 2^q + 1 shape
+            n: 128,
+            t: 32, // plaintext modulus
+            p: 0,  // unused in this test
+        };
 
         let mut rng = rand::thread_rng();
 
         for _ in 0..100 {
-            let (sk, pk) = S::new_key(&mut rng)?;
+            let (sk, pk) = BFV::new_key(&mut rng, &params)?;
 
-            let msg_dist = Uniform::new(0_u64, T);
-            let m1 = Rq::<T, N>::rand_u64(&mut rng, msg_dist)?;
-            let m2 = Rq::<T, N>::rand_u64(&mut rng, msg_dist)?;
+            let msg_dist = Uniform::new(0_u64, params.t);
+            let m1 = Rq::rand_u64(&mut rng, msg_dist, params.t, params.n)?;
+            let m2 = Rq::rand_u64(&mut rng, msg_dist, params.t, params.n)?;
 
-            let c1 = S::encrypt(&mut rng, &pk, &m1)?;
-            let c2 = S::encrypt(&mut rng, &pk, &m2)?;
+            let c1 = BFV::encrypt(&mut rng, &params, &pk, &m1)?;
+            let c2 = BFV::encrypt(&mut rng, &params, &pk, &m2)?;
 
             let c3 = c1 + c2;
 
-            let m3_recovered = S::decrypt(&sk, &c3);
+            let m3_recovered = BFV::decrypt(&params, &sk, &c3);
 
             assert_eq!(m1 + m2, m3_recovered);
         }
@@ -292,211 +324,210 @@ mod tests {
 
     #[test]
     fn test_constant_add_mul() -> Result<()> {
-        const Q: u64 = 2u64.pow(16) + 1;
-        const N: usize = 16;
-        const T: u64 = 8; // plaintext modulus
-        type S = BFV<Q, N, T>;
+        let q: u64 = 2u64.pow(16) + 1; // q prime, and 2^q + 1 shape
+        let params = Params {
+            q,
+            n: 16,
+            t: 8, // plaintext modulus
+            p: q * q,
+        };
 
         let mut rng = rand::thread_rng();
 
-        let (sk, pk) = S::new_key(&mut rng)?;
+        let (sk, pk) = BFV::new_key(&mut rng, &params)?;
 
-        let msg_dist = Uniform::new(0_u64, T);
-        let m1 = Rq::<T, N>::rand_u64(&mut rng, msg_dist)?;
-        let m2_const = Rq::<T, N>::rand_u64(&mut rng, msg_dist)?;
-        let c1 = S::encrypt(&mut rng, &pk, &m1)?;
+        let msg_dist = Uniform::new(0_u64, params.t);
+        let m1 = Rq::rand_u64(&mut rng, msg_dist, params.t, params.n)?;
+        let m2_const = Rq::rand_u64(&mut rng, msg_dist, params.t, params.n)?;
+        let c1 = BFV::encrypt(&mut rng, &params, &pk, &m1)?;
 
         let c3_add = &c1 + &m2_const;
 
-        let m3_add_recovered = S::decrypt(&sk, &c3_add);
-        assert_eq!(m1 + m2_const, m3_add_recovered);
+        let m3_add_recovered = BFV::decrypt(&params, &sk, &c3_add);
+        assert_eq!(&m1 + &m2_const, m3_add_recovered);
 
         // test multiplication of a ciphertext by a constant
-        const P: u64 = Q * Q;
-        const PQ: u64 = P * Q;
-        let rlk = BFV::<Q, N, T>::rlk_key::<PQ>(&mut rng, &sk)?;
+        let rlk = BFV::rlk_key(&mut rng, &params, &sk)?;
 
-        let c3_mul = S::mul_const(&rlk, &c1, &m2_const);
+        let c3_mul = BFV::mul_const(&rlk, &c1, &m2_const);
 
-        let m3_mul_recovered = S::decrypt(&sk, &c3_mul);
+        let m3_mul_recovered = BFV::decrypt(&params, &sk, &c3_mul);
         assert_eq!(
-            (m1.to_r() * m2_const.to_r()).to_rq::<T>().coeffs(),
+            (m1.to_r() * m2_const.to_r()).to_rq(params.t).coeffs(),
             m3_mul_recovered.coeffs()
         );
 
         Ok(())
     }
 
-    // TMP WIP
-    #[test]
-    #[ignore]
-    fn test_params() -> Result<()> {
-        const Q: u64 = 2u64.pow(16) + 1; // q prime, and 2^q + 1 shape
-        const N: usize = 32;
-        const T: u64 = 8; // plaintext modulus
+    /*
+        // TMP WIP
+        #[test]
+        #[ignore]
+        fn test_params() -> Result<()> {
+            const Q: u64 = 2u64.pow(16) + 1; // q prime, and 2^q + 1 shape
+            const N: usize = 32;
+            const T: u64 = 8; // plaintext modulus
 
-        const P: u64 = Q * Q;
-        const PQ: u64 = P * Q;
-        const DELTA: u64 = Q / T; // floor
+            const P: u64 = Q * Q;
+            const PQ: u64 = P * Q;
+            const DELTA: u64 = Q / T; // floor
 
-        let mut rng = rand::thread_rng();
+            let mut rng = rand::thread_rng();
 
-        let Xi_key = Uniform::new(0_f64, 1_f64);
-        let Xi_err = Normal::new(0_f64, ERR_SIGMA)?;
+            let Xi_key = Uniform::new(0_f64, 1_f64);
+            let Xi_err = Normal::new(0_f64, ERR_SIGMA)?;
 
-        let s = Rq::<Q, N>::rand_f64(&mut rng, Xi_key)?;
-        let e = Rq::<Q, N>::rand_f64(&mut rng, Xi_err)?;
-        let u = Rq::<Q, N>::rand_f64(&mut rng, Xi_key)?;
-        let e_0 = Rq::<Q, N>::rand_f64(&mut rng, Xi_err)?;
-        let e_1 = Rq::<Q, N>::rand_f64(&mut rng, Xi_err)?;
-        let m = Rq::<Q, N>::rand_u64(&mut rng, Uniform::new(0_u64, T))?;
+            let s = Rq::rand_f64(&mut rng, Xi_key)?;
+            let e = Rq::rand_f64(&mut rng, Xi_err)?;
+            let u = Rq::rand_f64(&mut rng, Xi_key)?;
+            let e_0 = Rq::rand_f64(&mut rng, Xi_err)?;
+            let e_1 = Rq::rand_f64(&mut rng, Xi_err)?;
+            let m = Rq::rand_u64(&mut rng, Uniform::new(0_u64, T))?;
 
-        // v_fresh
-        let v: Rq<Q, N> = u * e + e_1 * s + e_0;
+            // v_fresh
+            let v: Rq<Q, N> = u * e + e_1 * s + e_0;
 
-        let q: f64 = Q as f64;
-        let t: f64 = T as f64;
-        let n: f64 = N as f64;
-        let delta: f64 = DELTA as f64;
+            let q: f64 = Q as f64;
+            let t: f64 = T as f64;
+            let n: f64 = N as f64;
+            let delta: f64 = DELTA as f64;
 
-        // r_t(q)/t should be equal to q/t-Δ
-        assert_eq!(
-            // r_t(q)/t, where r_t(q)=q mod t
-            (q % t) / t,
-            // Δt/Q = q - r_t(Q)/Q, so r_t(Q)=q - Δt
-            (q / t) - delta
-        );
-        let rt: f64 = (q % t) / t;
-        dbg!(&rt);
+            // r_t(q)/t should be equal to q/t-Δ
+            assert_eq!(
+                // r_t(q)/t, where r_t(q)=q mod t
+                (q % t) / t,
+                // Δt/Q = q - r_t(Q)/Q, so r_t(Q)=q - Δt
+                (q / t) - delta
+            );
+            let rt: f64 = (q % t) / t;
+            dbg!(&rt);
 
-        dbg!(v.infinity_norm());
-        let bound: f64 = (q / (2_f64 * t)) - (rt / 2_f64);
-        dbg!(bound);
-        assert!((v.infinity_norm() as f64) < bound);
-        let max_v_infnorm = bound - 1.0;
+            dbg!(v.infinity_norm());
+            let bound: f64 = (q / (2_f64 * t)) - (rt / 2_f64);
+            dbg!(bound);
+            assert!((v.infinity_norm() as f64) < bound);
+            let max_v_infnorm = bound - 1.0;
 
-        // addition noise
-        let v_add: Rq<Q, N> = v + v + u * rt;
-        let v_add: Rq<Q, N> = v_add + v_add + u * rt;
-        assert!((v_add.infinity_norm() as f64) < bound);
+            // addition noise
+            let v_add: Rq<Q, N> = v + v + u * rt;
+            let v_add: Rq<Q, N> = v_add + v_add + u * rt;
+            assert!((v_add.infinity_norm() as f64) < bound);
 
-        // multiplication noise
-        let (_, pk) = BFV::<Q, N, T>::new_key(&mut rng)?;
-        let c = BFV::<Q, N, T>::encrypt(&mut rng, &pk, &m.remodule::<T>())?;
-        let b_key: f64 = 1_f64;
-        // ef: expansion factor
-        let ef: f64 = 2.0 * n.sqrt();
-        let bound: f64 = ((ef * t) / 2.0)
-            * ((2.0 * max_v_infnorm * max_v_infnorm) / q
-                + (4.0 + ef * b_key) * (max_v_infnorm + max_v_infnorm)
-                + rt * (ef * b_key + 5.0))
-            + (1.0 + ef * b_key + ef * ef * b_key * b_key) / 2.0;
-        dbg!(&bound);
+            // multiplication noise
+            let (_, pk) = BFV::<Q, N, T>::new_key(&mut rng)?;
+            let c = BFV::<Q, N, T>::encrypt(&mut rng, &pk, &m.remodule::<T>())?;
+            let b_key: f64 = 1_f64;
+            // ef: expansion factor
+            let ef: f64 = 2.0 * n.sqrt();
+            let bound: f64 = ((ef * t) / 2.0)
+                * ((2.0 * max_v_infnorm * max_v_infnorm) / q
+                    + (4.0 + ef * b_key) * (max_v_infnorm + max_v_infnorm)
+                    + rt * (ef * b_key + 5.0))
+                + (1.0 + ef * b_key + ef * ef * b_key * b_key) / 2.0;
+            dbg!(&bound);
 
-        let k: Vec<f64> = (c.0 + c.1 * s - m * delta - v)
-            .coeffs()
-            .iter()
-            .map(|e_i| e_i.0 as f64 / q)
-            .collect();
-        let k = Rq::<Q, N>::from_vec_f64(k);
-        let v_tensor_0 = (v * v)
-            .coeffs()
-            .iter()
-            .map(|e_i| (e_i.0 as f64 * t) / q)
-            .collect::<Vec<f64>>();
-        let v_tensor_0 = Rq::<Q, N>::from_vec_f64(v_tensor_0);
-        let v_tensor_1 = ((m * v) + (m * v))
-            .coeffs()
-            .iter()
-            .map(|e_i| (e_i.0 as f64 * t * delta) / q)
-            .collect::<Vec<f64>>();
-        let v_tensor_1 = Rq::<Q, N>::from_vec_f64(v_tensor_1);
-        let v_tensor_2: Rq<Q, N> = (v * k + v * k) * t;
-        let rm: f64 = (ef * t) / 2.0;
-        let rm: Rq<Q, N> = Rq::<Q, N>::from_vec_f64(vec![rm; N]);
-        let v_tensor_3: Rq<Q, N> = (m * k
-            + m * k
-            + rm
-            + Rq::from_vec_f64(
-                ((m * m) * DELTA)
-                    .coeffs()
-                    .iter()
-                    .map(|e_i| e_i.0 as f64 / q)
-                    .collect::<Vec<f64>>(),
-            ))
-            * rt;
-        let v_tensor = v_tensor_0 + v_tensor_1 + v_tensor_2 - v_tensor_3;
+            let k: Vec<f64> = (c.0 + c.1 * s - m * delta - v)
+                .coeffs()
+                .iter()
+                .map(|e_i| e_i.0 as f64 / q)
+                .collect();
+            let k = Rq::from_vec_f64(k);
+            let v_tensor_0 = (v * v)
+                .coeffs()
+                .iter()
+                .map(|e_i| (e_i.0 as f64 * t) / q)
+                .collect::<Vec<f64>>();
+            let v_tensor_0 = Rq::from_vec_f64(v_tensor_0);
+            let v_tensor_1 = ((m * v) + (m * v))
+                .coeffs()
+                .iter()
+                .map(|e_i| (e_i.0 as f64 * t * delta) / q)
+                .collect::<Vec<f64>>();
+            let v_tensor_1 = Rq::from_vec_f64(v_tensor_1);
+            let v_tensor_2: Rq<Q, N> = (v * k + v * k) * t;
+            let rm: f64 = (ef * t) / 2.0;
+            let rm: Rq<Q, N> = Rq::from_vec_f64(vec![rm; N]);
+            let v_tensor_3: Rq<Q, N> = (m * k
+                + m * k
+                + rm
+                + Rq::from_vec_f64(
+                    ((m * m) * DELTA)
+                        .coeffs()
+                        .iter()
+                        .map(|e_i| e_i.0 as f64 / q)
+                        .collect::<Vec<f64>>(),
+                ))
+                * rt;
+            let v_tensor = v_tensor_0 + v_tensor_1 + v_tensor_2 - v_tensor_3;
 
-        let v_r = (1.0 + ef * b_key + ef * ef * b_key * b_key) / 2.0;
-        let v_mult_norm = v_tensor.infinity_norm() as f64 + v_r;
-        dbg!(&v_mult_norm);
-        dbg!(&bound);
-        assert!(v_mult_norm < bound);
+            let v_r = (1.0 + ef * b_key + ef * ef * b_key * b_key) / 2.0;
+            let v_mult_norm = v_tensor.infinity_norm() as f64 + v_r;
+            dbg!(&v_mult_norm);
+            dbg!(&bound);
+            assert!(v_mult_norm < bound);
 
-        // let m1 = Rq::<T, N>::zero();
-        // let m2 = Rq::<T, N>::zero();
-        // let (_, pk) = BFV::<Q, N, T>::new_key(&mut rng)?;
-        // let c1 = BFV::<Q, N, T>::encrypt(&mut rng, &pk, &m1)?;
-        // let c2 = BFV::<Q, N, T>::encrypt(&mut rng, &pk, &m2)?;
-        // let (c_a, c_b, c_c) = RLWE::<Q, N>::tensor::<PQ, T>(&c1, &c2);
-        // dbg!(&c_a.infinity_norm());
-        // dbg!(&c_b.infinity_norm());
-        // dbg!(&c_c.infinity_norm());
-        // assert!((c_a.infinity_norm() as f64) < bound);
-        // assert!((c_b.infinity_norm() as f64) < bound);
-        // assert!((c_c.infinity_norm() as f64) < bound);
-        // WIP
+            // let m1 = Rq::<T, N>::zero();
+            // let m2 = Rq::<T, N>::zero();
+            // let (_, pk) = BFV::<Q, N, T>::new_key(&mut rng)?;
+            // let c1 = BFV::<Q, N, T>::encrypt(&mut rng, &pk, &m1)?;
+            // let c2 = BFV::<Q, N, T>::encrypt(&mut rng, &pk, &m2)?;
+            // let (c_a, c_b, c_c) = RLWE::tensor::<PQ, T>(&c1, &c2);
+            // dbg!(&c_a.infinity_norm());
+            // dbg!(&c_b.infinity_norm());
+            // dbg!(&c_c.infinity_norm());
+            // assert!((c_a.infinity_norm() as f64) < bound);
+            // assert!((c_b.infinity_norm() as f64) < bound);
+            // assert!((c_c.infinity_norm() as f64) < bound);
+            // WIP
 
-        Ok(())
-    }
+            Ok(())
+        }
+    */
 
     #[test]
     fn test_tensor() -> Result<()> {
-        const Q: u64 = 2u64.pow(16) + 1; // q prime, and 2^q + 1 shape
-        const N: usize = 16;
-        const T: u64 = 2; // plaintext modulus
-
-        // const P: u64 = Q;
-        const P: u64 = Q * Q;
-        const PQ: u64 = P * Q;
-
+        let q: u64 = 2u64.pow(16) + 1; // q prime, and 2^q + 1 shape
+        let params = Params {
+            q,
+            n: 16,
+            t: 2, // plaintext modulus
+            p: q * q,
+        };
         let mut rng = rand::thread_rng();
 
-        let msg_dist = Uniform::new(0_u64, T);
+        let msg_dist = Uniform::new(0_u64, params.t);
         for _ in 0..1_000 {
-            let m1 = Rq::<T, N>::rand_u64(&mut rng, msg_dist)?;
-            let m2 = Rq::<T, N>::rand_u64(&mut rng, msg_dist)?;
+            let m1 = Rq::rand_u64(&mut rng, msg_dist, params.t, params.n)?;
+            let m2 = Rq::rand_u64(&mut rng, msg_dist, params.t, params.n)?;
 
-            test_tensor_opt::<Q, N, T, PQ>(&mut rng, m1, m2)?;
+            test_tensor_opt(&mut rng, &params, m1, m2)?;
         }
 
         Ok(())
     }
-    fn test_tensor_opt<const Q: u64, const N: usize, const T: u64, const PQ: u64>(
-        mut rng: impl Rng,
-        m1: Rq<T, N>,
-        m2: Rq<T, N>,
-    ) -> Result<()> {
-        let (sk, pk) = BFV::<Q, N, T>::new_key(&mut rng)?;
+    fn test_tensor_opt(mut rng: impl Rng, params: &Params, m1: Rq, m2: Rq) -> Result<()> {
+        let (sk, pk) = BFV::new_key(&mut rng, &params)?;
 
-        let c1 = BFV::<Q, N, T>::encrypt(&mut rng, &pk, &m1)?;
-        let c2 = BFV::<Q, N, T>::encrypt(&mut rng, &pk, &m2)?;
+        let c1 = BFV::encrypt(&mut rng, &params, &pk, &m1)?;
+        let c2 = BFV::encrypt(&mut rng, &params, &pk, &m2)?;
 
-        let (c_a, c_b, c_c) = RLWE::<Q, N>::tensor::<PQ, T>(&c1, &c2);
-        // let (c_a, c_b, c_c) = RLWE::<Q, N>::tensor_new::<PQ, T>(&c1, &c2);
+        let (c_a, c_b, c_c) = RLWE::tensor(params.t, &c1, &c2);
+        // let (c_a, c_b, c_c) = RLWE::tensor_new::<PQ, T>(&c1, &c2);
 
         // decrypt non-relinearized mul result
-        let m3: Rq<Q, N> = c_a + c_b * sk.0 + c_c * sk.0 * sk.0;
+        let m3: Rq = c_a + &c_b * &sk.0 + &c_c * &(&sk.0 * &sk.0);
+
         // let m3: Rq<Q, N> = c_a
-        //     + Rq::<Q, N>::from_vec_i64(arith::ring_n::naive_mul(&c_b.to_r(), &sk.0.to_r()))
-        //     + Rq::<Q, N>::from_vec_i64(arith::ring_n::naive_mul(
+        //     + Rq::from_vec_i64(arith::ring_n::naive_mul(&c_b.to_r(), &sk.0.to_r()))
+        //     + Rq::from_vec_i64(arith::ring_n::naive_mul(
         //         &c_c.to_r(),
         //         &R::<N>::from_vec(arith::ring_n::naive_mul(&sk.0.to_r(), &sk.0.to_r())),
         //     ));
-        let m3: Rq<Q, N> = m3.mul_div_round(T, Q); // descale
-        let m3 = m3.remodule::<T>();
+        let m3: Rq = m3.mul_div_round(params.t, params.q); // descale
+        let m3 = m3.remodule(params.t);
 
-        let naive = (m1.to_r() * m2.to_r()).to_rq::<T>();
+        let naive = (m1.clone().to_r() * m2.clone().to_r()).to_rq(params.t); // TODO rm clones
         assert_eq!(
             m3.coeffs().to_vec(),
             naive.coeffs().to_vec(),
@@ -510,44 +541,40 @@ mod tests {
 
     #[test]
     fn test_mul_relin() -> Result<()> {
-        const Q: u64 = 2u64.pow(16) + 1;
-        const N: usize = 16;
-        const T: u64 = 2; // plaintext modulus
-        type S = BFV<Q, N, T>;
-
-        const P: u64 = Q * Q;
-        const PQ: u64 = P * Q;
+        let q: u64 = 2u64.pow(16) + 1; // q prime, and 2^q + 1 shape
+        let params = Params {
+            q,
+            n: 16,
+            t: 2, // plaintext modulus
+            p: q * q,
+        };
 
         let mut rng = rand::thread_rng();
-        let msg_dist = Uniform::new(0_u64, T);
+        let msg_dist = Uniform::new(0_u64, params.t);
 
         for _ in 0..1_000 {
-            let m1 = Rq::<T, N>::rand_u64(&mut rng, msg_dist)?;
-            let m2 = Rq::<T, N>::rand_u64(&mut rng, msg_dist)?;
+            let m1 = Rq::rand_u64(&mut rng, msg_dist, params.t, params.n)?;
+            let m2 = Rq::rand_u64(&mut rng, msg_dist, params.t, params.n)?;
 
-            test_mul_relin_opt::<Q, N, T, PQ>(&mut rng, m1, m2)?;
+            test_mul_relin_opt(&mut rng, &params, m1, m2)?;
         }
 
         Ok(())
     }
 
-    fn test_mul_relin_opt<const Q: u64, const N: usize, const T: u64, const PQ: u64>(
-        mut rng: impl Rng,
-        m1: Rq<T, N>,
-        m2: Rq<T, N>,
-    ) -> Result<()> {
-        let (sk, pk) = BFV::<Q, N, T>::new_key(&mut rng)?;
+    fn test_mul_relin_opt(mut rng: impl Rng, params: &Params, m1: Rq, m2: Rq) -> Result<()> {
+        let (sk, pk) = BFV::new_key(&mut rng, &params)?;
 
-        let rlk = BFV::<Q, N, T>::rlk_key::<PQ>(&mut rng, &sk)?;
+        let rlk = BFV::rlk_key(&mut rng, &params, &sk)?;
 
-        let c1 = BFV::<Q, N, T>::encrypt(&mut rng, &pk, &m1)?;
-        let c2 = BFV::<Q, N, T>::encrypt(&mut rng, &pk, &m2)?;
+        let c1 = BFV::encrypt(&mut rng, &params, &pk, &m1)?;
+        let c2 = BFV::encrypt(&mut rng, &params, &pk, &m2)?;
 
-        let c3 = RLWE::<Q, N>::mul::<PQ, T>(&rlk, &c1, &c2); // uses relinearize internally
+        let c3 = RLWE::mul(params.t, &rlk, &c1, &c2); // uses relinearize internally
 
-        let m3 = BFV::<Q, N, T>::decrypt(&sk, &c3);
+        let m3 = BFV::decrypt(&params, &sk, &c3);
 
-        let naive = (m1.to_r() * m2.to_r()).to_rq::<T>();
+        let naive = (m1.clone().to_r() * m2.clone().to_r()).to_rq(params.t); // TODO rm clones
         assert_eq!(
             m3.coeffs().to_vec(),
             naive.coeffs().to_vec(),

--- a/bfv/src/lib.rs
+++ b/bfv/src/lib.rs
@@ -16,6 +16,14 @@ use arith::{Ring, Rq, R};
 // sigma=3.2 from: https://eprint.iacr.org/2022/162.pdf page 5
 const ERR_SIGMA: f64 = 3.2;
 
+#[derive(Clone, Copy, Debug)]
+pub struct Params {
+    q: u64,
+    n: usize,
+    t: u64,
+    p: u64,
+}
+
 #[derive(Clone, Debug)]
 pub struct SecretKey(Rq);
 
@@ -92,12 +100,6 @@ impl ops::Add<&Rq> for &RLWE {
     }
 }
 
-pub struct Params {
-    q: u64,
-    n: usize,
-    t: u64,
-    p: u64,
-}
 pub struct BFV {}
 
 impl BFV {

--- a/ckks/src/encoder.rs
+++ b/ckks/src/encoder.rs
@@ -3,12 +3,13 @@ use anyhow::Result;
 use arith::{Matrix, Ring, Rq, C, R};
 
 #[derive(Clone, Debug)]
-pub struct SecretKey<const Q: u64, const N: usize>(Rq<Q, N>);
+pub struct SecretKey(Rq);
 
 #[derive(Clone, Debug)]
-pub struct PublicKey<const Q: u64, const N: usize>(Rq<Q, N>, Rq<Q, N>);
+pub struct PublicKey(Rq, Rq);
 
-pub struct Encoder<const Q: u64, const N: usize> {
+pub struct Encoder {
+    n: usize,
     scale_factor: C<f64>, // Δ (delta)
     primitive: C<f64>,
     basis: Matrix<C<f64>>,
@@ -34,13 +35,14 @@ fn vandermonde(n: usize, w: C<f64>) -> Matrix<C<f64>> {
     }
     Matrix::<C<f64>>(v)
 }
-impl<const Q: u64, const N: usize> Encoder<Q, N> {
-    pub fn new(scale_factor: C<f64>) -> Self {
-        let primitive: C<f64> = primitive_root_of_unity(2 * N);
-        let basis = vandermonde(N, primitive);
+impl Encoder {
+    pub fn new(n: usize, scale_factor: C<f64>) -> Self {
+        let primitive: C<f64> = primitive_root_of_unity(2 * n);
+        let basis = vandermonde(n, primitive);
         let basis_t = basis.transpose();
 
         Self {
+            n,
             scale_factor,
             primitive,
             basis,
@@ -52,7 +54,7 @@ impl<const Q: u64, const N: usize> Encoder<Q, N> {
     /// from $\mathbb{C}^{N/2} \longrightarrow \mathbb{Z_q}[X]/(X^N +1) = R$
     // TODO use alg.1 from 2018-1043,
     //      or as in 2018-1073: $f(x) = 1N (U^T.conj() m + U^T m.conj())$
-    pub fn encode(&self, z: &[C<f64>]) -> Result<R<N>> {
+    pub fn encode(&self, z: &[C<f64>]) -> Result<R> {
         // $pi^{-1}: \mathbb{C}^{N/2} \longrightarrow \mathbb{H}$
         let expanded = self.pi_inv(z);
 
@@ -93,10 +95,10 @@ impl<const Q: u64, const N: usize> Encoder<Q, N> {
 
         // TMP: naive round, maybe do gaussian
         let coeffs = r.iter().map(|e| e.re.round() as i64).collect::<Vec<i64>>();
-        Ok(R::from_vec(coeffs))
+        Ok(R::from_vec(self.n, coeffs))
     }
 
-    pub fn decode(&self, p: &R<N>) -> Result<Vec<C<f64>>> {
+    pub fn decode(&self, p: &R) -> Result<Vec<C<f64>>> {
         let p: Vec<C<f64>> = p
             .coeffs()
             .iter()
@@ -110,7 +112,7 @@ impl<const Q: u64, const N: usize> Encoder<Q, N> {
 
     /// pi: \mathbb{H} \longrightarrow \mathbb{C}^{N/2}
     fn pi(&self, z: &[C<f64>]) -> Vec<C<f64>> {
-        z[..N / 2].to_vec()
+        z[..self.n / 2].to_vec()
     }
     /// pi^{-1}: \mathbb{C}^{N/2} \longrightarrow \mathbb{H}
     fn pi_inv(&self, z: &[C<f64>]) -> Vec<C<f64>> {
@@ -154,6 +156,7 @@ mod tests {
     fn test_encode_decode() -> Result<()> {
         const Q: u64 = 1024;
         const N: usize = 32;
+        let n: usize = 32;
 
         let T = 128; // WIP
         let mut rng = rand::thread_rng();
@@ -166,9 +169,9 @@ mod tests {
             .collect();
 
             let delta = C::<f64>::new(64.0, 0.0); // delta = scaling factor
-            let encoder = Encoder::<Q, N>::new(delta);
+            let encoder = Encoder::new(n, delta);
 
-            let m: R<N> = encoder.encode(&z)?; // polynomial (encoded vec) \in R
+            let m: R = encoder.encode(&z)?; // polynomial (encoded vec) \in R
 
             let z_decoded = encoder.decode(&m)?;
 

--- a/ckks/src/encoder.rs
+++ b/ckks/src/encoder.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 
-use arith::{Matrix, Ring, Rq, C, R};
+use arith::{Matrix, Rq, C, R};
 
 #[derive(Clone, Debug)]
 pub struct SecretKey(Rq);

--- a/ckks/src/lib.rs
+++ b/ckks/src/lib.rs
@@ -154,7 +154,6 @@ mod tests {
                 .map(|e| (*e as f64 / (scale_factor_u64 as f64)).round() as u64)
                 .collect();
             let m_decrypted = Rq::from_vec_u64(&param.ring, m_decrypted);
-            // assert_eq!(m_decrypted, Rq::from(m_raw));
             assert_eq!(m_decrypted, m_raw.to_rq(q));
         }
 

--- a/ckks/src/lib.rs
+++ b/ckks/src/lib.rs
@@ -18,35 +18,48 @@ pub use encoder::Encoder;
 // sigma=3.2 from: https://eprint.iacr.org/2016/421.pdf page 17
 const ERR_SIGMA: f64 = 3.2;
 
-#[derive(Debug)]
-pub struct PublicKey<const Q: u64, const N: usize>(Rq<Q, N>, Rq<Q, N>);
-
-pub struct SecretKey<const Q: u64, const N: usize>(Rq<Q, N>);
-
-pub struct CKKS<const Q: u64, const N: usize> {
-    encoder: Encoder<Q, N>,
+#[derive(Clone, Copy, Debug)]
+pub struct Params {
+    q: u64,
+    n: usize,
+    t: u64,
 }
 
-impl<const Q: u64, const N: usize> CKKS<Q, N> {
-    pub fn new(delta: C<f64>) -> Self {
-        let encoder = Encoder::<Q, N>::new(delta);
-        Self { encoder }
+#[derive(Debug)]
+pub struct PublicKey(Rq, Rq);
+
+pub struct SecretKey(Rq);
+
+pub struct CKKS {
+    params: Params,
+    encoder: Encoder,
+}
+
+impl CKKS {
+    pub fn new(params: &Params, delta: C<f64>) -> Self {
+        let encoder = Encoder::new(params.n, delta);
+        Self {
+            params: params.clone(),
+            encoder,
+        }
     }
     /// generate a new key pair (privK, pubK)
-    pub fn new_key(&self, mut rng: impl Rng) -> Result<(SecretKey<Q, N>, PublicKey<Q, N>)> {
+    pub fn new_key(&self, mut rng: impl Rng) -> Result<(SecretKey, PublicKey)> {
+        let params = &self.params;
+
         let Xi_key = Uniform::new(-1_f64, 1_f64);
         let Xi_err = Normal::new(0_f64, ERR_SIGMA)?;
 
-        let e = Rq::<Q, N>::rand_f64(&mut rng, Xi_err)?;
+        let e = Rq::rand_f64(&mut rng, Xi_err, params.q, params.n)?;
 
-        let mut s = Rq::<Q, N>::rand_f64(&mut rng, Xi_key)?;
+        let mut s = Rq::rand_f64(&mut rng, Xi_key, params.q, params.n)?;
         // since s is going to be multiplied by other Rq elements, already
         // compute its NTT
         s.compute_evals();
 
-        let a = Rq::<Q, N>::rand_f64(&mut rng, Xi_key)?;
+        let a = Rq::rand_f64(&mut rng, Xi_key, params.q, params.n)?;
 
-        let pk: PublicKey<Q, N> = PublicKey((&(-a) * &s) + e, a.clone());
+        let pk: PublicKey = PublicKey((&(-a.clone()) * &s) + e, a.clone()); // TODO rm clones
         Ok((SecretKey(s), pk))
     }
 
@@ -54,64 +67,54 @@ impl<const Q: u64, const N: usize> CKKS<Q, N> {
     fn encrypt(
         &self, // TODO maybe rm?
         mut rng: impl Rng,
-        pk: &PublicKey<Q, N>,
-        m: &R<N>,
-    ) -> Result<(Rq<Q, N>, Rq<Q, N>)> {
+        pk: &PublicKey,
+        m: &R,
+    ) -> Result<(Rq, Rq)> {
+        let params = self.params;
         let Xi_key = Uniform::new(-1_f64, 1_f64);
         let Xi_err = Normal::new(0_f64, ERR_SIGMA)?;
 
-        let e_0 = Rq::<Q, N>::rand_f64(&mut rng, Xi_err)?;
-        let e_1 = Rq::<Q, N>::rand_f64(&mut rng, Xi_err)?;
+        let e_0 = Rq::rand_f64(&mut rng, Xi_err, params.q, params.n)?;
+        let e_1 = Rq::rand_f64(&mut rng, Xi_err, params.q, params.n)?;
 
-        let v = Rq::<Q, N>::rand_f64(&mut rng, Xi_key)?;
+        let v = Rq::rand_f64(&mut rng, Xi_key, params.q, params.n)?;
 
-        let m: Rq<Q, N> = Rq::<Q, N>::from(*m);
+        // let m: Rq = Rq::from(*m);
+        let m: Rq = m.clone().to_rq(params.q); // TODO rm clone
 
-        Ok((m + e_0 + v * pk.0.clone(), v * pk.1.clone() + e_1))
+        Ok((m + e_0 + &v * &pk.0.clone(), &v * &pk.1 + e_1))
     }
 
     fn decrypt(
         &self, // TODO maybe rm?
-        sk: &SecretKey<Q, N>,
-        c: (Rq<Q, N>, Rq<Q, N>),
-    ) -> Result<R<N>> {
-        let m = c.0.clone() + c.1 * sk.0;
+        sk: &SecretKey,
+        c: (Rq, Rq),
+    ) -> Result<R> {
+        let m = c.0.clone() + &c.1 * &sk.0;
         Ok(m.mod_centered_q())
     }
 
     pub fn encode_and_encrypt(
         &self,
         mut rng: impl Rng,
-        pk: &PublicKey<Q, N>,
+        pk: &PublicKey,
         z: &[C<f64>],
-    ) -> Result<(Rq<Q, N>, Rq<Q, N>)> {
-        let m: R<N> = self.encoder.encode(&z)?; // polynomial (encoded vec) \in R
+    ) -> Result<(Rq, Rq)> {
+        let m: R = self.encoder.encode(&z)?; // polynomial (encoded vec) \in R
 
         self.encrypt(&mut rng, pk, &m)
     }
 
-    pub fn decrypt_and_decode(
-        &self,
-        sk: SecretKey<Q, N>,
-        c: (Rq<Q, N>, Rq<Q, N>),
-    ) -> Result<Vec<C<f64>>> {
+    pub fn decrypt_and_decode(&self, sk: SecretKey, c: (Rq, Rq)) -> Result<Vec<C<f64>>> {
         let d = self.decrypt(&sk, c)?;
 
         self.encoder.decode(&d)
     }
 
-    pub fn add(
-        &self,
-        c0: &(Rq<Q, N>, Rq<Q, N>),
-        c1: &(Rq<Q, N>, Rq<Q, N>),
-    ) -> Result<(Rq<Q, N>, Rq<Q, N>)> {
+    pub fn add(&self, c0: &(Rq, Rq), c1: &(Rq, Rq)) -> Result<(Rq, Rq)> {
         Ok((&c0.0 + &c1.0, &c0.1 + &c1.1))
     }
-    pub fn sub(
-        &self,
-        c0: &(Rq<Q, N>, Rq<Q, N>),
-        c1: &(Rq<Q, N>, Rq<Q, N>),
-    ) -> Result<(Rq<Q, N>, Rq<Q, N>)> {
+    pub fn sub(&self, c0: &(Rq, Rq), c1: &(Rq, Rq)) -> Result<(Rq, Rq)> {
         Ok((&c0.0 - &c1.0, &c0.1 + &c1.1))
     }
 }
@@ -122,21 +125,22 @@ mod tests {
 
     #[test]
     fn test_encrypt_decrypt() -> Result<()> {
-        const Q: u64 = 2u64.pow(16) + 1;
-        const N: usize = 32;
-        const T: u64 = 50;
+        let q: u64 = 2u64.pow(16) + 1;
+        let n: usize = 32;
+        let t: u64 = 50;
+        let params = Params { q, n, t };
         let scale_factor_u64 = 512_u64; // delta
         let scale_factor = C::<f64>::new(scale_factor_u64 as f64, 0.0); // delta
 
         let mut rng = rand::thread_rng();
 
         for _ in 0..1000 {
-            let ckks = CKKS::<Q, N>::new(scale_factor);
+            let ckks = CKKS::new(&params, scale_factor);
 
             let (sk, pk) = ckks.new_key(&mut rng)?;
 
-            let m_raw: R<N> = Rq::<Q, N>::rand_f64(&mut rng, Uniform::new(0_f64, T as f64))?.to_r();
-            let m = m_raw * scale_factor_u64;
+            let m_raw: R = Rq::rand_f64(&mut rng, Uniform::new(0_f64, t as f64), q, n)?.to_r();
+            let m = &m_raw * &scale_factor_u64;
 
             let ct = ckks.encrypt(&mut rng, &pk, &m)?;
             let m_decrypted = ckks.decrypt(&sk, ct)?;
@@ -146,8 +150,9 @@ mod tests {
                 .iter()
                 .map(|e| (*e as f64 / (scale_factor_u64 as f64)).round() as u64)
                 .collect();
-            let m_decrypted = Rq::<Q, N>::from_vec_u64(m_decrypted);
-            assert_eq!(m_decrypted, Rq::<Q, N>::from(m_raw));
+            let m_decrypted = Rq::from_vec_u64(q, n, m_decrypted);
+            // assert_eq!(m_decrypted, Rq::from(m_raw));
+            assert_eq!(m_decrypted, m_raw.to_rq(q));
         }
 
         Ok(())
@@ -155,21 +160,22 @@ mod tests {
 
     #[test]
     fn test_encode_encrypt_decrypt_decode() -> Result<()> {
-        const Q: u64 = 2u64.pow(16) + 1;
-        const N: usize = 16;
-        const T: u64 = 8;
+        let q: u64 = 2u64.pow(16) + 1;
+        let n: usize = 16;
+        let t: u64 = 8;
+        let params = Params { q, n, t };
         let scale_factor = C::<f64>::new(512.0, 0.0); // delta
 
         let mut rng = rand::thread_rng();
 
         for _ in 0..1000 {
-            let ckks = CKKS::<Q, N>::new(scale_factor);
+            let ckks = CKKS::new(&params, scale_factor);
             let (sk, pk) = ckks.new_key(&mut rng)?;
 
-            let z: Vec<C<f64>> = std::iter::repeat_with(|| C::<f64>::rand(&mut rng, T))
-                .take(N / 2)
+            let z: Vec<C<f64>> = std::iter::repeat_with(|| C::<f64>::rand(&mut rng, t))
+                .take(n / 2)
                 .collect();
-            let m: R<N> = ckks.encoder.encode(&z)?;
+            let m: R = ckks.encoder.encode(&z)?;
             println!("{}", m);
 
             // sanity check
@@ -200,26 +206,27 @@ mod tests {
 
     #[test]
     fn test_add() -> Result<()> {
-        const Q: u64 = 2u64.pow(16) + 1;
-        const N: usize = 16;
-        const T: u64 = 8;
+        let q: u64 = 2u64.pow(16) + 1;
+        let n: usize = 16;
+        let t: u64 = 8;
+        let params = Params { q, n, t };
         let scale_factor = C::<f64>::new(1024.0, 0.0); // delta
 
         let mut rng = rand::thread_rng();
 
         for _ in 0..1000 {
-            let ckks = CKKS::<Q, N>::new(scale_factor);
+            let ckks = CKKS::new(&params, scale_factor);
 
             let (sk, pk) = ckks.new_key(&mut rng)?;
 
-            let z0: Vec<C<f64>> = std::iter::repeat_with(|| C::<f64>::rand(&mut rng, T))
-                .take(N / 2)
+            let z0: Vec<C<f64>> = std::iter::repeat_with(|| C::<f64>::rand(&mut rng, t))
+                .take(n / 2)
                 .collect();
-            let z1: Vec<C<f64>> = std::iter::repeat_with(|| C::<f64>::rand(&mut rng, T))
-                .take(N / 2)
+            let z1: Vec<C<f64>> = std::iter::repeat_with(|| C::<f64>::rand(&mut rng, t))
+                .take(n / 2)
                 .collect();
-            let m0: R<N> = ckks.encoder.encode(&z0)?;
-            let m1: R<N> = ckks.encoder.encode(&z1)?;
+            let m0: R = ckks.encoder.encode(&z0)?;
+            let m1: R = ckks.encoder.encode(&z1)?;
 
             let ct0 = ckks.encrypt(&mut rng, &pk, &m0)?;
             let ct1 = ckks.encrypt(&mut rng, &pk, &m1)?;
@@ -243,26 +250,27 @@ mod tests {
 
     #[test]
     fn test_sub() -> Result<()> {
-        const Q: u64 = 2u64.pow(16) + 1;
-        const N: usize = 16;
-        const T: u64 = 8;
+        let q: u64 = 2u64.pow(16) + 1;
+        let n: usize = 16;
+        let t: u64 = 8;
+        let params = Params { q, n, t };
         let scale_factor = C::<f64>::new(1024.0, 0.0); // delta
 
         let mut rng = rand::thread_rng();
 
         for _ in 0..1000 {
-            let ckks = CKKS::<Q, N>::new(scale_factor);
+            let ckks = CKKS::new(&params, scale_factor);
 
             let (sk, pk) = ckks.new_key(&mut rng)?;
 
-            let z0: Vec<C<f64>> = std::iter::repeat_with(|| C::<f64>::rand(&mut rng, T))
-                .take(N / 2)
+            let z0: Vec<C<f64>> = std::iter::repeat_with(|| C::<f64>::rand(&mut rng, t))
+                .take(n / 2)
                 .collect();
-            let z1: Vec<C<f64>> = std::iter::repeat_with(|| C::<f64>::rand(&mut rng, T))
-                .take(N / 2)
+            let z1: Vec<C<f64>> = std::iter::repeat_with(|| C::<f64>::rand(&mut rng, t))
+                .take(n / 2)
                 .collect();
-            let m0: R<N> = ckks.encoder.encode(&z0)?;
-            let m1: R<N> = ckks.encoder.encode(&z1)?;
+            let m0: R = ckks.encoder.encode(&z0)?;
+            let m1: R = ckks.encoder.encode(&z1)?;
 
             let ct0 = ckks.encrypt(&mut rng, &pk, &m0)?;
             let ct1 = ckks.encrypt(&mut rng, &pk, &m1)?;

--- a/gfhe/src/glev.rs
+++ b/gfhe/src/glev.rs
@@ -1,10 +1,9 @@
 use anyhow::Result;
 use itertools::zip_eq;
 use rand::Rng;
-use rand_distr::{Normal, Uniform};
-use std::ops::{Add, Mul};
+use std::ops::Mul;
 
-use arith::{Ring, TR};
+use arith::Ring;
 
 use crate::glwe::{Param, PublicKey, SecretKey, GLWE};
 
@@ -41,7 +40,6 @@ impl<R: Ring> GLev<R> {
         l: u32,
         sk: &SecretKey<R>,
         m: &R,
-        // delta: u64,
     ) -> Result<Self> {
         let glev: Vec<GLWE<R>> = (1..l + 1)
             .map(|i| {
@@ -69,6 +67,7 @@ impl<R: Ring> GLev<R> {
 impl<R: Ring> Mul<Vec<R>> for GLev<R> {
     type Output = GLWE<R>;
     fn mul(self, v: Vec<R>) -> GLWE<R> {
+        debug_assert_eq!(self.0.len(), v.len());
         // TODO debug_assert_eq of param
 
         // l times GLWES
@@ -91,6 +90,7 @@ mod tests {
     #[test]
     fn test_encrypt_decrypt() -> Result<()> {
         let param = Param {
+            err_sigma: crate::glwe::ERR_SIGMA,
             ring: RingParam {
                 q: 2u64.pow(16) + 1,
                 n: 128,
@@ -103,7 +103,6 @@ mod tests {
         let beta: u32 = 2;
         let l: u32 = 16;
 
-        // let delta: u64 = Q / T; // floored
         let mut rng = rand::thread_rng();
         let msg_dist = Uniform::new(0_u64, param.t);
 

--- a/gfhe/src/glev.rs
+++ b/gfhe/src/glev.rs
@@ -69,7 +69,7 @@ impl<R: Ring> GLev<R> {
 impl<R: Ring> Mul<Vec<R>> for GLev<R> {
     type Output = GLWE<R>;
     fn mul(self, v: Vec<R>) -> GLWE<R> {
-        // TODO debug_assert_eq of params
+        // TODO debug_assert_eq of param
 
         // l times GLWES
         let glwes: Vec<GLWE<R>> = self.0;

--- a/gfhe/src/glev.rs
+++ b/gfhe/src/glev.rs
@@ -6,23 +6,29 @@ use std::ops::{Add, Mul};
 
 use arith::{Ring, TR};
 
-use crate::glwe::{PublicKey, SecretKey, GLWE};
+use crate::glwe::{Param, PublicKey, SecretKey, GLWE};
 
 // l GLWEs
 #[derive(Clone, Debug)]
-pub struct GLev<R: Ring, const K: usize>(pub(crate) Vec<GLWE<R, K>>);
+pub struct GLev<R: Ring>(pub(crate) Vec<GLWE<R>>);
 
-impl<R: Ring, const K: usize> GLev<R, K> {
+impl<R: Ring> GLev<R> {
     pub fn encrypt(
         mut rng: impl Rng,
+        param: &Param,
         beta: u32,
         l: u32,
-        pk: &PublicKey<R, K>,
+        pk: &PublicKey<R>,
         m: &R,
     ) -> Result<Self> {
-        let glev: Vec<GLWE<R, K>> = (0..l)
+        let glev: Vec<GLWE<R>> = (0..l)
             .map(|i| {
-                GLWE::<R, K>::encrypt(&mut rng, pk, &(*m * (R::Q / beta.pow(i as u32) as u64)))
+                GLWE::<R>::encrypt(
+                    &mut rng,
+                    param,
+                    pk,
+                    &(m.clone() * (param.ring.q / beta.pow(i as u32) as u64)),
+                )
             })
             .collect::<Result<Vec<_>>>()?;
 
@@ -30,38 +36,46 @@ impl<R: Ring, const K: usize> GLev<R, K> {
     }
     pub fn encrypt_s(
         mut rng: impl Rng,
+        param: &Param,
         beta: u32,
         l: u32,
-        sk: &SecretKey<R, K>,
+        sk: &SecretKey<R>,
         m: &R,
         // delta: u64,
     ) -> Result<Self> {
-        let glev: Vec<GLWE<R, K>> = (1..l + 1)
+        let glev: Vec<GLWE<R>> = (1..l + 1)
             .map(|i| {
-                GLWE::<R, K>::encrypt_s(&mut rng, sk, &(*m * (R::Q / beta.pow(i as u32) as u64)))
+                GLWE::<R>::encrypt_s(
+                    &mut rng,
+                    param,
+                    sk,
+                    &(m.clone() * (param.ring.q / beta.pow(i as u32) as u64)), // TODO rm clone
+                )
             })
             .collect::<Result<Vec<_>>>()?;
 
         Ok(Self(glev))
     }
 
-    pub fn decrypt<const T: u64>(&self, sk: &SecretKey<R, K>, beta: u32) -> R {
+    pub fn decrypt(&self, param: &Param, sk: &SecretKey<R>, beta: u32) -> R {
         let pt = self.0[1].decrypt(sk);
-        pt.mul_div_round(beta as u64, R::Q)
+        pt.mul_div_round(beta as u64, param.ring.q)
     }
 }
 
 // dot product between a GLev and Vec<R>.
 // Used for operating decompositions with KSK_i.
 // GLev * Vec<R> --> GLWE
-impl<R: Ring, const K: usize> Mul<Vec<R>> for GLev<R, K> {
-    type Output = GLWE<R, K>;
-    fn mul(self, v: Vec<R>) -> GLWE<R, K> {
+impl<R: Ring> Mul<Vec<R>> for GLev<R> {
+    type Output = GLWE<R>;
+    fn mul(self, v: Vec<R>) -> GLWE<R> {
+        // TODO debug_assert_eq of params
+
         // l times GLWES
-        let glwes: Vec<GLWE<R, K>> = self.0;
+        let glwes: Vec<GLWE<R>> = self.0;
 
         // l iterations
-        let r: GLWE<R, K> = zip_eq(v, glwes).map(|(v_i, glwe_i)| glwe_i * v_i).sum();
+        let r: GLWE<R> = zip_eq(v, glwes).map(|(v_i, glwe_i)| glwe_i * v_i).sum();
         r
     }
 }
@@ -72,33 +86,37 @@ mod tests {
     use rand::distributions::Uniform;
 
     use super::*;
-    use arith::Rq;
+    use arith::{RingParam, Rq};
 
     #[test]
     fn test_encrypt_decrypt() -> Result<()> {
-        const Q: u64 = 2u64.pow(16) + 1;
-        const N: usize = 128;
-        const T: u64 = 2; // plaintext modulus
-        const K: usize = 16;
-        type S = GLev<Rq<Q, N>, K>;
+        let param = Param {
+            ring: RingParam {
+                q: 2u64.pow(16) + 1,
+                n: 128,
+            },
+            k: 16,
+            t: 2, // plaintext modulus
+        };
+        type S = GLev<Rq>;
 
         let beta: u32 = 2;
         let l: u32 = 16;
 
         // let delta: u64 = Q / T; // floored
         let mut rng = rand::thread_rng();
-        let msg_dist = Uniform::new(0_u64, T);
+        let msg_dist = Uniform::new(0_u64, param.t);
 
         for _ in 0..200 {
-            let (sk, pk) = GLWE::<Rq<Q, N>, K>::new_key(&mut rng)?;
+            let (sk, pk) = GLWE::<Rq>::new_key(&mut rng, &param)?;
 
-            let m = Rq::<T, N>::rand_u64(&mut rng, msg_dist)?;
-            let m: Rq<Q, N> = m.remodule::<Q>();
+            let m = Rq::rand_u64(&mut rng, msg_dist, &param.pt())?;
+            let m: Rq = m.remodule(param.ring.q);
 
-            let c = S::encrypt(&mut rng, beta, l, &pk, &m)?;
-            let m_recovered = c.decrypt::<T>(&sk, beta);
+            let c = S::encrypt(&mut rng, &param, beta, l, &pk, &m)?;
+            let m_recovered = c.decrypt(&param, &sk, beta);
 
-            assert_eq!(m.remodule::<T>(), m_recovered.remodule::<T>());
+            assert_eq!(m.remodule(param.t), m_recovered.remodule(param.t));
         }
 
         Ok(())

--- a/gfhe/src/glwe.rs
+++ b/gfhe/src/glwe.rs
@@ -8,79 +8,108 @@ use rand_distr::{Normal, Uniform};
 use std::iter::Sum;
 use std::ops::{Add, AddAssign, Mul, Sub};
 
-use arith::{Ring, Rq, Zq, TR};
+use arith::{Ring, RingParam, Rq, Zq, TR};
 
 use crate::glev::GLev;
 
 // const ERR_SIGMA: f64 = 3.2;
 const ERR_SIGMA: f64 = 0.0; // TODO WIP
 
+#[derive(Clone, Copy, Debug)]
+pub struct Param {
+    pub ring: RingParam,
+    pub k: usize,
+    pub t: u64,
+}
+impl Param {
+    // returns the plaintext params
+    pub fn pt(&self) -> RingParam {
+        RingParam {
+            q: self.t,
+            n: self.ring.n,
+        }
+    }
+}
+
 /// GLWE implemented over the `Ring` trait, so that it can be also instantiated
 /// over the Torus polynomials 𝕋_<N,q>[X] = 𝕋_q[X]/ (X^N+1).
 #[derive(Clone, Debug)]
-pub struct GLWE<R: Ring, const K: usize>(pub TR<R, K>, pub R);
+pub struct GLWE<R: Ring>(pub TR<R>, pub R);
 
 #[derive(Clone, Debug)]
-pub struct SecretKey<R: Ring, const K: usize>(pub TR<R, K>);
+pub struct SecretKey<R: Ring>(pub TR<R>);
 #[derive(Clone, Debug)]
-pub struct PublicKey<R: Ring, const K: usize>(pub R, pub TR<R, K>);
+pub struct PublicKey<R: Ring>(pub R, pub TR<R>);
 
 // K GLevs, each KSK_i=l GLWEs
 #[derive(Clone, Debug)]
-pub struct KSK<R: Ring, const K: usize>(Vec<GLev<R, K>>);
+pub struct KSK<R: Ring>(Vec<GLev<R>>);
 
-impl<R: Ring, const K: usize> GLWE<R, K> {
-    pub fn zero() -> Self {
-        Self(TR::zero(), R::zero())
+impl<R: Ring> GLWE<R> {
+    pub fn zero(k: usize, params: &RingParam) -> Self {
+        Self(TR::zero(k, &params), R::zero(&params))
     }
-    pub fn from_plaintext(p: R) -> Self {
-        Self(TR::zero(), p)
+    pub fn from_plaintext(k: usize, param: &RingParam, p: R) -> Self {
+        Self(TR::zero(k, &param), p)
     }
 
-    pub fn new_key(mut rng: impl Rng) -> Result<(SecretKey<R, K>, PublicKey<R, K>)> {
+    pub fn new_key(mut rng: impl Rng, param: &Param) -> Result<(SecretKey<R>, PublicKey<R>)> {
         let Xi_key = Uniform::new(0_f64, 2_f64);
         let Xi_err = Normal::new(0_f64, ERR_SIGMA)?;
 
-        let s: TR<R, K> = TR::rand(&mut rng, Xi_key);
-        let a: TR<R, K> = TR::rand(&mut rng, Uniform::new(0_f64, R::Q as f64));
-        let e = R::rand(&mut rng, Xi_err);
+        let s: TR<R> = TR::rand(&mut rng, Xi_key, param.k, &param.ring);
+        let a: TR<R> = TR::rand(
+            &mut rng,
+            Uniform::new(0_f64, param.ring.q as f64),
+            param.k,
+            &param.ring,
+        );
+        let e = R::rand(&mut rng, Xi_err, &param.ring);
 
-        let pk: PublicKey<R, K> = PublicKey((&a * &s) + e, a);
+        let pk: PublicKey<R> = PublicKey((&a * &s) + e, a);
         Ok((SecretKey(s), pk))
     }
-    pub fn pk_from_sk(mut rng: impl Rng, sk: SecretKey<R, K>) -> Result<PublicKey<R, K>> {
+    pub fn pk_from_sk(mut rng: impl Rng, param: &Param, sk: SecretKey<R>) -> Result<PublicKey<R>> {
         let Xi_err = Normal::new(0_f64, ERR_SIGMA)?;
 
-        let a: TR<R, K> = TR::rand(&mut rng, Uniform::new(0_f64, R::Q as f64));
-        let e = R::rand(&mut rng, Xi_err);
+        let a: TR<R> = TR::rand(
+            &mut rng,
+            Uniform::new(0_f64, param.ring.q as f64),
+            param.k,
+            &param.ring,
+        );
+        let e = R::rand(&mut rng, Xi_err, &param.ring);
 
-        let pk: PublicKey<R, K> = PublicKey((&a * &sk.0) + e, a);
+        let pk: PublicKey<R> = PublicKey((&a * &sk.0) + e, a);
         Ok(pk)
     }
 
     pub fn new_ksk(
         mut rng: impl Rng,
+        param: &Param,
         beta: u32,
         l: u32,
-        sk: &SecretKey<R, K>,
-        new_sk: &SecretKey<R, K>,
-    ) -> Result<KSK<R, K>> {
-        let r: Vec<GLev<R, K>> = (0..K)
+        sk: &SecretKey<R>,
+        new_sk: &SecretKey<R>,
+    ) -> Result<KSK<R>> {
+        debug_assert_eq!(param.k, sk.0.k);
+        let k = sk.0.k;
+        let r: Vec<GLev<R>> = (0..k)
             .into_iter()
             .map(|i|
                 // treat sk_i as the msg being encrypted
-                GLev::<R, K>::encrypt_s(&mut rng, beta, l, &new_sk, &sk.0 .0[i]))
+                GLev::<R>::encrypt_s(&mut rng, param, beta, l, &new_sk, &sk.0 .r[i]))
             .collect::<Result<Vec<_>>>()?;
 
         Ok(KSK(r))
     }
-    pub fn key_switch(&self, beta: u32, l: u32, ksk: &KSK<R, K>) -> Self {
-        let (a, b): (TR<R, K>, R) = (self.0.clone(), self.1);
+    pub fn key_switch(&self, param: &Param, beta: u32, l: u32, ksk: &KSK<R>) -> Self {
+        let (a, b): (TR<R>, R) = (self.0.clone(), self.1.clone()); // TODO rm clones
 
-        let lhs: GLWE<R, K> = GLWE(TR::zero(), b);
+        let lhs: GLWE<R> = GLWE(TR::zero(param.k, &param.ring), b);
 
         // K iterations, ksk.0 contains K times GLev
-        let rhs: GLWE<R, K> = zip_eq(a.0, ksk.0.clone())
+        let rhs: GLWE<R> = zip_eq(a.r, ksk.0.clone())
             .map(|(a_i, ksk_i)| ksk_i * a_i.decompose(beta, l)) // dot_product
             .sum();
 
@@ -90,121 +119,136 @@ impl<R: Ring, const K: usize> GLWE<R, K> {
     // encrypts with the given SecretKey (instead of PublicKey)
     pub fn encrypt_s(
         mut rng: impl Rng,
-        sk: &SecretKey<R, K>,
+        param: &Param,
+        sk: &SecretKey<R>,
         m: &R, // already scaled
     ) -> Result<Self> {
         let Xi_key = Uniform::new(0_f64, 2_f64);
         let Xi_err = Normal::new(0_f64, ERR_SIGMA)?;
 
-        let a: TR<R, K> = TR::rand(&mut rng, Xi_key);
-        let e = R::rand(&mut rng, Xi_err);
+        let a: TR<R> = TR::rand(&mut rng, Xi_key, param.k, &param.ring);
+        let e = R::rand(&mut rng, Xi_err, &param.ring);
 
-        let b: R = (&a * &sk.0) + *m + e;
+        let b: R = (&a * &sk.0) + m.clone() + e; // TODO rm clone
         Ok(Self(a, b))
     }
     pub fn encrypt(
         mut rng: impl Rng,
-        pk: &PublicKey<R, K>,
+        param: &Param,
+        pk: &PublicKey<R>,
         m: &R, // already scaled
     ) -> Result<Self> {
         let Xi_key = Uniform::new(0_f64, 2_f64);
         let Xi_err = Normal::new(0_f64, ERR_SIGMA)?;
 
-        let u: R = R::rand(&mut rng, Xi_key);
+        let u: R = R::rand(&mut rng, Xi_key, &param.ring);
 
-        let e0 = R::rand(&mut rng, Xi_err);
-        let e1 = TR::<R, K>::rand(&mut rng, Xi_err);
+        let e0 = R::rand(&mut rng, Xi_err, &param.ring);
+        let e1 = TR::<R>::rand(&mut rng, Xi_err, param.k, &param.ring);
 
-        let b: R = pk.0.clone() * u.clone() + *m + e0;
-        let d: TR<R, K> = &pk.1 * &u + e1;
+        let b: R = pk.0.clone() * u.clone() + m.clone() + e0; // TODO rm clones
+        let d: TR<R> = &pk.1 * &u + e1;
 
         Ok(Self(d, b))
     }
     // returns m' not downscaled
-    pub fn decrypt(&self, sk: &SecretKey<R, K>) -> R {
-        let (d, b): (TR<R, K>, R) = (self.0.clone(), self.1);
+    pub fn decrypt(&self, sk: &SecretKey<R>) -> R {
+        let (d, b): (TR<R>, R) = (self.0.clone(), self.1.clone());
         let p: R = b - &d * &sk.0;
         p
     }
 }
 
 // Methods for when Ring=Rq<Q,N>
-impl<const Q: u64, const N: usize, const K: usize> GLWE<Rq<Q, N>, K> {
+impl GLWE<Rq> {
     // scale up
-    pub fn encode<const T: u64>(m: &Rq<T, N>) -> Rq<Q, N> {
-        let m = m.remodule::<Q>();
-        let delta = Q / T; // floored
+    pub fn encode(param: &Param, m: &Rq) -> Rq {
+        debug_assert_eq!(param.t, m.param.q);
+        let m = m.remodule(param.ring.q);
+        let delta = param.ring.q / param.t; // floored
         m * delta
     }
     // scale down
-    pub fn decode<const T: u64>(m: &Rq<Q, N>) -> Rq<T, N> {
-        let r = m.mul_div_round(T, Q);
-        let r: Rq<T, N> = r.remodule::<T>();
+    pub fn decode(param: &Param, m: &Rq) -> Rq {
+        let r = m.mul_div_round(param.t, param.ring.q);
+        let r: Rq = r.remodule(param.t);
         r
     }
-    pub fn mod_switch<const P: u64>(&self) -> GLWE<Rq<P, N>, K> {
-        let a: TR<Rq<P, N>, K> = TR(self
-            .0
-             .0
-            .iter()
-            .map(|r| r.mod_switch::<P>())
-            .collect::<Vec<_>>());
-        let b: Rq<P, N> = self.1.mod_switch::<P>();
+    pub fn mod_switch(&self, p: u64) -> GLWE<Rq> {
+        let a: TR<Rq> = TR {
+            k: self.0.k,
+            r: self.0.r.iter().map(|r| r.mod_switch(p)).collect::<Vec<_>>(),
+        };
+        let b: Rq = self.1.mod_switch(p);
         GLWE(a, b)
     }
 }
 
-impl<R: Ring, const K: usize> Add<GLWE<R, K>> for GLWE<R, K> {
+impl<R: Ring> Add<GLWE<R>> for GLWE<R> {
     type Output = Self;
     fn add(self, other: Self) -> Self {
-        let a: TR<R, K> = self.0 + other.0;
+        let a: TR<R> = self.0 + other.0;
         let b: R = self.1 + other.1;
         Self(a, b)
     }
 }
 
-impl<R: Ring, const K: usize> Add<R> for GLWE<R, K> {
+impl<R: Ring> Add<R> for GLWE<R> {
     type Output = Self;
     fn add(self, plaintext: R) -> Self {
-        let a: TR<R, K> = self.0;
+        let a: TR<R> = self.0;
         let b: R = self.1 + plaintext;
         Self(a, b)
     }
 }
-impl<R: Ring, const K: usize> AddAssign for GLWE<R, K> {
+impl<R: Ring> AddAssign for GLWE<R> {
     fn add_assign(&mut self, rhs: Self) {
-        for i in 0..K {
-            self.0 .0[i] = self.0 .0[i].clone() + rhs.0 .0[i].clone();
+        debug_assert_eq!(self.0.k, rhs.0.k);
+        debug_assert_eq!(self.1.param(), rhs.1.param());
+
+        let k = self.0.k;
+        for i in 0..k {
+            self.0.r[i] = self.0.r[i].clone() + rhs.0.r[i].clone();
         }
         self.1 = self.1.clone() + rhs.1.clone();
     }
 }
-impl<R: Ring, const K: usize> Sum<GLWE<R, K>> for GLWE<R, K> {
-    fn sum<I>(iter: I) -> Self
+impl<R: Ring> Sum<GLWE<R>> for GLWE<R> {
+    fn sum<I>(mut iter: I) -> Self
     where
         I: Iterator<Item = Self>,
     {
-        let mut acc = GLWE::<R, K>::zero();
-        for e in iter {
-            acc += e;
-        }
-        acc
+        // let mut acc = GLWE::<R>::zero();
+        // for e in iter {
+        //     acc += e;
+        // }
+        // acc
+        let first = iter.next().unwrap();
+        iter.fold(first, |acc, e| acc + e)
     }
 }
 
-impl<R: Ring, const K: usize> Sub<GLWE<R, K>> for GLWE<R, K> {
+impl<R: Ring> Sub<GLWE<R>> for GLWE<R> {
     type Output = Self;
     fn sub(self, other: Self) -> Self {
-        let a: TR<R, K> = self.0 - other.0;
+        let a: TR<R> = self.0 - other.0;
         let b: R = self.1 - other.1;
         Self(a, b)
     }
 }
 
-impl<R: Ring, const K: usize> Mul<R> for GLWE<R, K> {
+impl<R: Ring> Mul<R> for GLWE<R> {
     type Output = Self;
     fn mul(self, plaintext: R) -> Self {
-        let a: TR<R, K> = TR(self.0 .0.iter().map(|r_i| *r_i * plaintext).collect());
+        let a: TR<R> = TR {
+            k: self.0.k,
+            r: self
+                .0
+                .r
+                .iter()
+                .map(|r_i| r_i.clone() * plaintext.clone())
+                .collect(),
+        };
         let b: R = self.1 * plaintext;
         Self(a, b)
     }
@@ -255,77 +299,93 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_encrypt_decrypt() -> Result<()> {
-        const Q: u64 = 2u64.pow(16) + 1;
-        const N: usize = 128;
-        const T: u64 = 32; // plaintext modulus
-        const K: usize = 16;
-        type S = GLWE<Rq<Q, N>, K>;
+    fn test_encrypt_decrypt_ring_nq() -> Result<()> {
+        let param = Param {
+            ring: RingParam {
+                q: 2u64.pow(16) + 1,
+                n: 128,
+            },
+            k: 16,
+            t: 32, // plaintext modulus
+        };
+        // let k: usize = 16;
+        type S = GLWE<Rq>;
 
         let mut rng = rand::thread_rng();
-        let msg_dist = Uniform::new(0_u64, T);
+        let msg_dist = Uniform::new(0_u64, param.t);
 
         for _ in 0..200 {
-            let (sk, pk) = S::new_key(&mut rng)?;
+            let (sk, pk) = S::new_key(&mut rng, &param)?;
 
-            let m = Rq::<T, N>::rand_u64(&mut rng, msg_dist)?; // msg
-                                                               // let m: Rq<Q, N> = m.remodule::<Q>();
+            let m = Rq::rand_u64(&mut rng, msg_dist, &param.pt())?; // msg
+                                                                    // let m: Rq<Q, N> = m.remodule::<Q>();
 
-            let p = S::encode::<T>(&m); // plaintext
-            let c = S::encrypt(&mut rng, &pk, &p)?; // ciphertext
+            let p = S::encode(&param, &m); // plaintext
+            let c = S::encrypt(&mut rng, &param, &pk, &p)?; // ciphertext
             let p_recovered = c.decrypt(&sk);
-            let m_recovered = S::decode::<T>(&p_recovered);
+            let m_recovered = S::decode(&param, &p_recovered);
 
-            assert_eq!(m.remodule::<T>(), m_recovered.remodule::<T>());
+            assert_eq!(m.remodule(param.t), m_recovered.remodule(param.t));
 
             // same but using encrypt_s (with sk instead of pk))
-            let c = S::encrypt_s(&mut rng, &sk, &p)?;
+            let c = S::encrypt_s(&mut rng, &param, &sk, &p)?;
             let p_recovered = c.decrypt(&sk);
-            let m_recovered = S::decode::<T>(&p_recovered);
+            let m_recovered = S::decode(&param, &p_recovered);
 
-            assert_eq!(m.remodule::<T>(), m_recovered.remodule::<T>());
+            assert_eq!(m.remodule(param.t), m_recovered.remodule(param.t));
         }
 
         Ok(())
     }
 
     use arith::{Tn, T64};
-    use std::array;
-    pub fn t_encode<const P: u64>(m: &Rq<P, 4>) -> Tn<4> {
-        let delta = u64::MAX / P; // floored
+    pub fn t_encode(param: &RingParam, m: &Rq) -> Tn {
+        let p = m.param.q; // plaintext space
+        let delta = u64::MAX / p; // floored
         let coeffs = m.coeffs();
-        Tn(array::from_fn(|i| T64(coeffs[i].0 * delta)))
+        // Tn(array::from_fn(|i| T64(coeffs[i].0 * delta)))
+        // Tn{param, coeffs: array::from_fn(|i| T64(coeffs[i].0 * delta)))
+        Tn {
+            param: *param,
+            coeffs: coeffs.iter().map(|c_i| T64(c_i.v * delta)).collect(),
+        }
     }
-    pub fn t_decode<const P: u64>(p: &Tn<4>) -> Rq<P, 4> {
-        let p = p.mul_div_round(P, u64::MAX);
-        Rq::<P, 4>::from_vec_u64(p.coeffs().iter().map(|c| c.0).collect())
+    pub fn t_decode(param: &Param, pt: &Tn) -> Rq {
+        let p = param.t;
+        let pt = pt.mul_div_round(p, u64::MAX);
+        Rq::from_vec_u64(&param.pt(), pt.coeffs().iter().map(|c| c.0).collect())
     }
     #[test]
     fn test_encrypt_decrypt_torus() -> Result<()> {
-        const N: usize = 128;
-        const T: u64 = 32; // plaintext modulus
-        const K: usize = 16;
-        type S = GLWE<Tn<4>, K>;
+        let param = Param {
+            ring: RingParam {
+                q: u64::MAX,
+                n: 128,
+            },
+            k: 16,
+            t: 32, // plaintext modulus
+        };
+        type S = GLWE<Tn>;
 
         let mut rng = rand::thread_rng();
-        let msg_dist = Uniform::new(0_f64, T as f64);
+        let msg_dist = Uniform::new(0_f64, param.t as f64);
 
         for _ in 0..200 {
-            let (sk, pk) = S::new_key(&mut rng)?;
+            let (sk, pk) = S::new_key(&mut rng, &param)?;
 
-            let m = Rq::<T, 4>::rand(&mut rng, msg_dist); // msg
+            let m = Rq::rand(&mut rng, msg_dist, &param.pt()); // msg
 
-            let p = t_encode::<T>(&m); // plaintext
-            let c = S::encrypt(&mut rng, &pk, &p)?; // ciphertext
+            let p = t_encode(&param.ring, &m); // plaintext
+            let c = S::encrypt(&mut rng, &param, &pk, &p)?; // ciphertext
             let p_recovered = c.decrypt(&sk);
-            let m_recovered = t_decode::<T>(&p_recovered);
+            let m_recovered = t_decode(&param, &p_recovered);
 
             assert_eq!(m, m_recovered);
 
             // same but using encrypt_s (with sk instead of pk))
-            let c = S::encrypt_s(&mut rng, &sk, &p)?;
+            let c = S::encrypt_s(&mut rng, &param, &sk, &p)?;
             let p_recovered = c.decrypt(&sk);
-            let m_recovered = t_decode::<T>(&p_recovered);
+            let m_recovered = t_decode(&param, &p_recovered);
 
             assert_eq!(m, m_recovered);
         }
@@ -335,32 +395,36 @@ mod tests {
 
     #[test]
     fn test_addition() -> Result<()> {
-        const Q: u64 = 2u64.pow(16) + 1;
-        const N: usize = 128;
-        const T: u64 = 20;
-        const K: usize = 16;
-        type S = GLWE<Rq<Q, N>, K>;
+        let param = Param {
+            ring: RingParam {
+                q: 2u64.pow(16) + 1,
+                n: 128,
+            },
+            k: 16,
+            t: 20, // plaintext modulus
+        };
+        type S = GLWE<Rq>;
 
         let mut rng = rand::thread_rng();
-        let msg_dist = Uniform::new(0_u64, T);
+        let msg_dist = Uniform::new(0_u64, param.t);
 
         for _ in 0..200 {
-            let (sk, pk) = S::new_key(&mut rng)?;
+            let (sk, pk) = S::new_key(&mut rng, &param)?;
 
-            let m1 = Rq::<T, N>::rand_u64(&mut rng, msg_dist)?;
-            let m2 = Rq::<T, N>::rand_u64(&mut rng, msg_dist)?;
-            let p1: Rq<Q, N> = S::encode::<T>(&m1); // plaintext
-            let p2: Rq<Q, N> = S::encode::<T>(&m2); // plaintext
+            let m1 = Rq::rand_u64(&mut rng, msg_dist, &param.pt())?;
+            let m2 = Rq::rand_u64(&mut rng, msg_dist, &param.pt())?;
+            let p1: Rq = S::encode(&param, &m1); // plaintext
+            let p2: Rq = S::encode(&param, &m2); // plaintext
 
-            let c1 = S::encrypt(&mut rng, &pk, &p1)?;
-            let c2 = S::encrypt(&mut rng, &pk, &p2)?;
+            let c1 = S::encrypt(&mut rng, &param, &pk, &p1)?;
+            let c2 = S::encrypt(&mut rng, &param, &pk, &p2)?;
 
             let c3 = c1 + c2;
 
             let p3_recovered = c3.decrypt(&sk);
-            let m3_recovered = S::decode::<T>(&p3_recovered);
+            let m3_recovered = S::decode(&param, &p3_recovered);
 
-            assert_eq!((m1 + m2).remodule::<T>(), m3_recovered.remodule::<T>());
+            assert_eq!((m1 + m2).remodule(param.t), m3_recovered.remodule(param.t));
         }
 
         Ok(())
@@ -368,31 +432,35 @@ mod tests {
 
     #[test]
     fn test_add_plaintext() -> Result<()> {
-        const Q: u64 = 2u64.pow(16) + 1;
-        const N: usize = 128;
-        const T: u64 = 32;
-        const K: usize = 16;
-        type S = GLWE<Rq<Q, N>, K>;
+        let param = Param {
+            ring: RingParam {
+                q: 2u64.pow(16) + 1,
+                n: 128,
+            },
+            k: 16,
+            t: 32, // plaintext modulus
+        };
+        type S = GLWE<Rq>;
 
         let mut rng = rand::thread_rng();
-        let msg_dist = Uniform::new(0_u64, T);
+        let msg_dist = Uniform::new(0_u64, param.t);
 
         for _ in 0..200 {
-            let (sk, pk) = S::new_key(&mut rng)?;
+            let (sk, pk) = S::new_key(&mut rng, &param)?;
 
-            let m1 = Rq::<T, N>::rand_u64(&mut rng, msg_dist)?;
-            let m2 = Rq::<T, N>::rand_u64(&mut rng, msg_dist)?;
-            let p1: Rq<Q, N> = S::encode::<T>(&m1); // plaintext
-            let p2: Rq<Q, N> = S::encode::<T>(&m2); // plaintext
+            let m1 = Rq::rand_u64(&mut rng, msg_dist, &param.pt())?;
+            let m2 = Rq::rand_u64(&mut rng, msg_dist, &param.pt())?;
+            let p1: Rq = S::encode(&param, &m1); // plaintext
+            let p2: Rq = S::encode(&param, &m2); // plaintext
 
-            let c1 = S::encrypt(&mut rng, &pk, &p1)?;
+            let c1 = S::encrypt(&mut rng, &param, &pk, &p1)?;
 
             let c3 = c1 + p2;
 
             let p3_recovered = c3.decrypt(&sk);
-            let m3_recovered = S::decode::<T>(&p3_recovered);
+            let m3_recovered = S::decode(&param, &p3_recovered);
 
-            assert_eq!((m1 + m2).remodule::<T>(), m3_recovered.remodule::<T>());
+            assert_eq!((m1 + m2).remodule(param.t), m3_recovered.remodule(param.t));
         }
 
         Ok(())
@@ -400,30 +468,34 @@ mod tests {
 
     #[test]
     fn test_mul_plaintext() -> Result<()> {
-        const Q: u64 = 2u64.pow(16) + 1;
-        const N: usize = 16;
-        const T: u64 = 4;
-        const K: usize = 16;
-        type S = GLWE<Rq<Q, N>, K>;
+        let param = Param {
+            ring: RingParam {
+                q: 2u64.pow(16) + 1,
+                n: 16,
+            },
+            k: 16,
+            t: 4, // plaintext modulus
+        };
+        type S = GLWE<Rq>;
 
         let mut rng = rand::thread_rng();
-        let msg_dist = Uniform::new(0_u64, T);
+        let msg_dist = Uniform::new(0_u64, param.t);
 
         for _ in 0..200 {
-            let (sk, pk) = S::new_key(&mut rng)?;
+            let (sk, pk) = S::new_key(&mut rng, &param)?;
 
-            let m1 = Rq::<T, N>::rand_u64(&mut rng, msg_dist)?;
-            let m2 = Rq::<T, N>::rand_u64(&mut rng, msg_dist)?;
-            let p1: Rq<Q, N> = S::encode::<T>(&m1); // plaintext
-            let p2 = m2.remodule::<Q>(); // notice we don't encode (scale by delta)
+            let m1 = Rq::rand_u64(&mut rng, msg_dist, &param.pt())?;
+            let m2 = Rq::rand_u64(&mut rng, msg_dist, &param.pt())?;
+            let p1: Rq = S::encode(&param, &m1); // plaintext
+            let p2 = m2.remodule(param.ring.q); // notice we don't encode (scale by delta)
 
-            let c1 = S::encrypt(&mut rng, &pk, &p1)?;
+            let c1 = S::encrypt(&mut rng, &param, &pk, &p1)?;
 
             let c3 = c1 * p2;
 
-            let p3_recovered: Rq<Q, N> = c3.decrypt(&sk);
-            let m3_recovered: Rq<T, N> = S::decode::<T>(&p3_recovered);
-            assert_eq!((m1.to_r() * m2.to_r()).to_rq::<T>(), m3_recovered);
+            let p3_recovered: Rq = c3.decrypt(&sk);
+            let m3_recovered: Rq = S::decode(&param, &p3_recovered);
+            assert_eq!((m1.to_r() * m2.to_r()).to_rq(param.t), m3_recovered);
         }
 
         Ok(())
@@ -431,33 +503,48 @@ mod tests {
 
     #[test]
     fn test_mod_switch() -> Result<()> {
-        const Q: u64 = 2u64.pow(16) + 1;
-        const P: u64 = 2u64.pow(8) + 1;
+        let param = Param {
+            ring: RingParam {
+                q: 2u64.pow(16) + 1,
+                n: 8,
+            },
+            k: 16,
+            t: 4, // plaintext modulus, must be a prime or power of a prime
+        };
+        let new_q: u64 = 2u64.pow(8) + 1;
         // note: wip, Q and P chosen so that P/Q is an integer
-        const N: usize = 8;
-        const T: u64 = 4; // plaintext modulus, must be a prime or power of a prime
-        const K: usize = 16;
-        type S = GLWE<Rq<Q, N>, K>;
+        type S = GLWE<Rq>;
 
         let mut rng = rand::thread_rng();
-        let msg_dist = Uniform::new(0_u64, T);
+        let msg_dist = Uniform::new(0_u64, param.t);
 
         for _ in 0..200 {
-            let (sk, pk) = S::new_key(&mut rng)?;
+            let (sk, pk) = S::new_key(&mut rng, &param)?;
 
-            let m = Rq::<T, N>::rand_u64(&mut rng, msg_dist)?;
+            let m = Rq::rand_u64(&mut rng, msg_dist, &param.pt())?;
 
-            let p = S::encode::<T>(&m);
-            let c = S::encrypt(&mut rng, &pk, &p)?;
+            let p = S::encode(&param, &m);
+            let c = S::encrypt(&mut rng, &param, &pk, &p)?;
 
-            let c2: GLWE<Rq<P, N>, K> = c.mod_switch::<P>();
-            let sk2: SecretKey<Rq<P, N>, K> =
-                SecretKey(TR(sk.0 .0.iter().map(|s_i| s_i.remodule::<P>()).collect()));
+            let c2: GLWE<Rq> = c.mod_switch(new_q);
+            assert_eq!(c2.1.param.q, new_q);
+            let sk2: SecretKey<Rq> = SecretKey(TR {
+                k: param.k,
+                r: sk.0.r.iter().map(|s_i| s_i.remodule(new_q)).collect(),
+            });
 
             let p_recovered = c2.decrypt(&sk2);
-            let m_recovered = GLWE::<Rq<P, N>, K>::decode::<T>(&p_recovered);
+            let new_param = Param {
+                ring: RingParam {
+                    q: new_q,
+                    n: param.ring.n,
+                },
+                k: param.k,
+                t: param.t,
+            };
+            let m_recovered = GLWE::<Rq>::decode(&new_param, &p_recovered);
 
-            assert_eq!(m.remodule::<T>(), m_recovered.remodule::<T>());
+            assert_eq!(m.remodule(param.t), m_recovered.remodule(param.t));
         }
 
         Ok(())
@@ -465,40 +552,44 @@ mod tests {
 
     #[test]
     fn test_key_switch() -> Result<()> {
-        const Q: u64 = 2u64.pow(16) + 1;
-        const N: usize = 128;
-        const T: u64 = 2; // plaintext modulus
-        const K: usize = 16;
-        type S = GLWE<Rq<Q, N>, K>;
+        let param = Param {
+            ring: RingParam {
+                q: 2u64.pow(16) + 1,
+                n: 128,
+            },
+            k: 16,
+            t: 2,
+        };
+        type S = GLWE<Rq>;
 
         let beta: u32 = 2;
         let l: u32 = 16;
 
         let mut rng = rand::thread_rng();
 
-        let (sk, pk) = S::new_key(&mut rng)?;
-        let (sk2, _) = S::new_key(&mut rng)?;
+        let (sk, pk) = S::new_key(&mut rng, &param)?;
+        let (sk2, _) = S::new_key(&mut rng, &param)?;
         // ksk to switch from sk to sk2
-        let ksk = S::new_ksk(&mut rng, beta, l, &sk, &sk2)?;
+        let ksk = S::new_ksk(&mut rng, &param, beta, l, &sk, &sk2)?;
 
-        let msg_dist = Uniform::new(0_u64, T);
-        let m = Rq::<T, N>::rand_u64(&mut rng, msg_dist)?;
-        let p = S::encode::<T>(&m); // plaintext
-                                    //
-        let c = S::encrypt_s(&mut rng, &sk, &p)?;
+        let msg_dist = Uniform::new(0_u64, param.t);
+        let m = Rq::rand_u64(&mut rng, msg_dist, &param.pt())?;
+        let p = S::encode(&param, &m); // plaintext
+                                       //
+        let c = S::encrypt_s(&mut rng, &param, &sk, &p)?;
 
-        let c2 = c.key_switch(beta, l, &ksk);
+        let c2 = c.key_switch(&param, beta, l, &ksk);
 
         // decrypt with the 2nd secret key
         let p_recovered = c2.decrypt(&sk2);
-        let m_recovered = S::decode::<T>(&p_recovered);
-        assert_eq!(m.remodule::<T>(), m_recovered.remodule::<T>());
+        let m_recovered = S::decode(&param, &p_recovered);
+        assert_eq!(m.remodule(param.t), m_recovered.remodule(param.t));
 
         // do the same but now encrypting with pk
-        let c = S::encrypt(&mut rng, &pk, &p)?;
-        let c2 = c.key_switch(beta, l, &ksk);
+        let c = S::encrypt(&mut rng, &param, &pk, &p)?;
+        let c2 = c.key_switch(&param, beta, l, &ksk);
         let p_recovered = c2.decrypt(&sk2);
-        let m_recovered = S::decode::<T>(&p_recovered);
+        let m_recovered = S::decode(&param, &p_recovered);
         assert_eq!(m, m_recovered);
 
         Ok(())

--- a/tfhe/src/lib.rs
+++ b/tfhe/src/lib.rs
@@ -10,3 +10,5 @@ pub mod tglwe;
 pub mod tgsw;
 pub mod tlev;
 pub mod tlwe;
+
+pub(crate) const ERR_SIGMA: f64 = 3.2;

--- a/tfhe/src/tggsw.rs
+++ b/tfhe/src/tggsw.rs
@@ -4,53 +4,57 @@ use rand::Rng;
 use std::array;
 use std::ops::{Add, Mul};
 
-use arith::{Ring, Rq, Tn, T64, TR};
+use arith::{Ring, RingParam, Rq, Tn, T64, TR};
 
 use crate::tglwe::{PublicKey, SecretKey, TGLWE};
-use gfhe::glwe::GLWE;
+use gfhe::glwe::{Param, GLWE};
 
 /// vector of length K+1 = ([K * TGLev], [1 * TGLev])
 #[derive(Clone, Debug)]
-pub struct TGGSW<const N: usize, const K: usize>(pub(crate) Vec<TGLev<N, K>>, TGLev<N, K>);
+pub struct TGGSW(pub(crate) Vec<TGLev>, TGLev);
 
-impl<const N: usize, const K: usize> TGGSW<N, K> {
+impl TGGSW {
     pub fn encrypt_s(
         mut rng: impl Rng,
+        param: &Param,
         beta: u32,
         l: u32,
-        sk: &SecretKey<N, K>,
-        m: &Tn<N>,
+        sk: &SecretKey,
+        m: &Tn,
     ) -> Result<Self> {
-        let a: Vec<TGLev<N, K>> = (0..K)
-            .map(|i| TGLev::encrypt_s(&mut rng, beta, l, sk, &(-sk.0 .0 .0[i] * *m)))
+        debug_assert_eq!(sk.0 .0.k, param.k);
+
+        let a: Vec<TGLev> = (0..param.k)
+            .map(|i| TGLev::encrypt_s(&mut rng, param, beta, l, sk, &(&-sk.0 .0.r[i].clone() * m)))
+            // TODO rm clone
             .collect::<Result<Vec<_>>>()?;
-        let b: TGLev<N, K> = TGLev::encrypt_s(&mut rng, beta, l, sk, m)?;
+        let b: TGLev = TGLev::encrypt_s(&mut rng, &param, beta, l, sk, m)?;
         Ok(Self(a, b))
     }
 
-    pub fn decrypt(&self, sk: &SecretKey<N, K>, beta: u32) -> Tn<N> {
+    pub fn decrypt(&self, sk: &SecretKey, beta: u32) -> Tn {
         self.1.decrypt(sk, beta)
     }
 
-    pub fn cmux(bit: Self, ct1: TGLWE<N, K>, ct2: TGLWE<N, K>) -> TGLWE<N, K> {
+    pub fn cmux(bit: Self, ct1: TGLWE, ct2: TGLWE) -> TGLWE {
         ct1.clone() + (bit * (ct2 - ct1))
     }
 }
 
-/// External product TGGSW x TGLWE
-impl<const N: usize, const K: usize> Mul<TGLWE<N, K>> for TGGSW<N, K> {
-    type Output = TGLWE<N, K>;
+/// External product tggsw x tglwe
+impl Mul<TGLWE> for TGGSW {
+    type Output = TGLWE;
 
-    fn mul(self, tglwe: TGLWE<N, K>) -> TGLWE<N, K> {
+    fn mul(self, tglwe: TGLWE) -> TGLWE {
         let beta: u32 = 2;
         let l: u32 = 64; // TODO wip
 
-        let tglwe_ab: Vec<Tn<N>> = [tglwe.0 .0 .0.clone(), vec![tglwe.0 .1]].concat();
+        let tglwe_ab: Vec<Tn> = [tglwe.0 .0.r.clone(), vec![tglwe.0 .1]].concat();
 
-        let tgsw_ab: Vec<TGLev<N, K>> = [self.0.clone(), vec![self.1]].concat();
+        let tgsw_ab: Vec<TGLev> = [self.0.clone(), vec![self.1]].concat();
         assert_eq!(tgsw_ab.len(), tglwe_ab.len());
 
-        let r: TGLWE<N, K> = zip_eq(tgsw_ab, tglwe_ab)
+        let r: TGLWE = zip_eq(tgsw_ab, tglwe_ab)
             .map(|(tlev_i, tglwe_i)| tlev_i * tglwe_i.decompose(beta, l))
             .sum();
         r
@@ -58,26 +62,36 @@ impl<const N: usize, const K: usize> Mul<TGLWE<N, K>> for TGGSW<N, K> {
 }
 
 #[derive(Clone, Debug)]
-pub struct TGLev<const N: usize, const K: usize>(pub(crate) Vec<TGLWE<N, K>>);
+pub struct TGLev(pub(crate) Vec<TGLWE>);
 
-impl<const N: usize, const K: usize> TGLev<N, K> {
-    pub fn encode<const T: u64>(m: &Rq<T, N>) -> Tn<N> {
-        let coeffs = m.coeffs();
-        Tn(array::from_fn(|i| T64(coeffs[i].0)))
+impl TGLev {
+    pub fn encode(param: &Param, m: &Rq) -> Tn {
+        debug_assert_eq!(param.t, m.param.q); // plaintext modulus
+
+        Tn {
+            param: param.ring,
+            coeffs: m.coeffs().iter().map(|c_i| T64(c_i.v)).collect(),
+        }
     }
-    pub fn decode<const T: u64>(p: &Tn<N>) -> Rq<T, N> {
-        Rq::<T, N>::from_vec_u64(p.coeffs().iter().map(|c| c.0).collect())
+    pub fn decode(param: &Param, p: &Tn) -> Rq {
+        Rq::from_vec_u64(&param.pt(), p.coeffs().iter().map(|c| c.0).collect())
     }
     pub fn encrypt(
         mut rng: impl Rng,
+        param: &Param,
         beta: u32,
         l: u32,
-        pk: &PublicKey<N, K>,
-        m: &Tn<N>,
+        pk: &PublicKey,
+        m: &Tn,
     ) -> Result<Self> {
-        let tlev: Vec<TGLWE<N, K>> = (1..l + 1)
+        let tlev: Vec<TGLWE> = (1..l + 1)
             .map(|i| {
-                TGLWE::<N, K>::encrypt(&mut rng, pk, &(*m * (u64::MAX / beta.pow(i as u32) as u64)))
+                TGLWE::encrypt(
+                    &mut rng,
+                    &param,
+                    pk,
+                    &(m * &(u64::MAX / beta.pow(i as u32) as u64)),
+                )
             })
             .collect::<Result<Vec<_>>>()?;
 
@@ -85,35 +99,36 @@ impl<const N: usize, const K: usize> TGLev<N, K> {
     }
     pub fn encrypt_s(
         mut rng: impl Rng,
+        param: &Param,
         _beta: u32, // TODO rm, and make beta=2 always
         l: u32,
-        sk: &SecretKey<N, K>,
-        m: &Tn<N>,
+        sk: &SecretKey,
+        m: &Tn,
     ) -> Result<Self> {
-        let tlev: Vec<TGLWE<N, K>> = (1..l as u64 + 1)
+        let tlev: Vec<TGLWE> = (1..l as u64 + 1)
             .map(|i| {
                 let aux = if i < 64 {
-                    *m * (u64::MAX / (1u64 << i))
+                    m * &(u64::MAX / (1u64 << i))
                 } else {
                     // 1<<64 would overflow, and anyways we're dividing u64::MAX
                     // by it, which would be equal to 1
-                    *m
+                    m.clone() // TODO rm clone
                 };
-                TGLWE::<N, K>::encrypt_s(&mut rng, sk, &aux)
+                TGLWE::encrypt_s(&mut rng, &param, sk, &aux)
             })
             .collect::<Result<Vec<_>>>()?;
 
         Ok(Self(tlev))
     }
 
-    pub fn decrypt(&self, sk: &SecretKey<N, K>, beta: u32) -> Tn<N> {
+    pub fn decrypt(&self, sk: &SecretKey, beta: u32) -> Tn {
         let pt = self.0[0].decrypt(sk);
         pt.mul_div_round(beta as u64, u64::MAX)
     }
 }
 
-impl<const N: usize, const K: usize> TGLev<N, K> {
-    pub fn iter(&self) -> std::slice::Iter<TGLWE<N, K>> {
+impl TGLev {
+    pub fn iter(&self) -> std::slice::Iter<TGLWE> {
         self.0.iter()
     }
 }
@@ -121,14 +136,14 @@ impl<const N: usize, const K: usize> TGLev<N, K> {
 // dot product between a TGLev and Vec<Tn<N>>, usually Vec<Tn<N>> comes from a
 // decomposition of Tn<N>
 // TGLev * Vec<Tn<N>> --> TGLWE
-impl<const N: usize, const K: usize> Mul<Vec<Tn<N>>> for TGLev<N, K> {
-    type Output = TGLWE<N, K>;
-    fn mul(self, v: Vec<Tn<N>>) -> Self::Output {
+impl Mul<Vec<Tn>> for TGLev {
+    type Output = TGLWE;
+    fn mul(self, v: Vec<Tn>) -> Self::Output {
         assert_eq!(self.0.len(), v.len());
 
         // l TGLWES
-        let tlwes: Vec<TGLWE<N, K>> = self.0;
-        let r: TGLWE<N, K> = zip_eq(v, tlwes).map(|(a_d_i, glwe_i)| glwe_i * a_d_i).sum();
+        let tlwes: Vec<TGLWE> = self.0;
+        let r: TGLWE = zip_eq(v, tlwes).map(|(a_d_i, glwe_i)| glwe_i * a_d_i).sum();
         r
     }
 }
@@ -141,38 +156,39 @@ mod tests {
     use super::*;
     #[test]
     fn test_external_product() -> Result<()> {
-        const T: u64 = 16; // plaintext modulus
-        const K: usize = 4;
-        const N: usize = 64;
-        const KN: usize = K * N;
+        let param = Param {
+            ring: RingParam { q: u64::MAX, n: 64 },
+            k: 4,
+            t: 16, // plaintext modulus
+        };
 
         let beta: u32 = 2;
         let l: u32 = 64;
 
         let mut rng = rand::thread_rng();
-        let msg_dist = Uniform::new(0_u64, T);
+        let msg_dist = Uniform::new(0_u64, param.t);
 
         for _ in 0..50 {
-            let (sk, _) = TGLWE::<N, K>::new_key::<KN>(&mut rng)?;
+            let (sk, _) = TGLWE::new_key(&mut rng, &param)?;
 
-            let m1: Rq<T, N> = Rq::rand_u64(&mut rng, msg_dist)?;
-            let p1: Tn<N> = TGLev::<N, K>::encode::<T>(&m1);
+            let m1: Rq = Rq::rand_u64(&mut rng, msg_dist, &param.pt())?;
+            let p1: Tn = TGLev::encode(&param, &m1);
 
-            let m2: Rq<T, N> = Rq::rand_u64(&mut rng, msg_dist)?;
-            let p2: Tn<N> = TGLWE::<N, K>::encode::<T>(&m2); // scaled by delta
+            let m2: Rq = Rq::rand_u64(&mut rng, msg_dist, &param.pt())?;
+            let p2: Tn = TGLWE::encode(&param, &m2); // scaled by delta
 
-            let tgsw = TGGSW::<N, K>::encrypt_s(&mut rng, beta, l, &sk, &p1)?;
-            let tlwe = TGLWE::<N, K>::encrypt_s(&mut rng, &sk, &p2)?;
+            let tgsw = TGGSW::encrypt_s(&mut rng, &param, beta, l, &sk, &p1)?;
+            let tlwe = TGLWE::encrypt_s(&mut rng, &param, &sk, &p2)?;
 
-            let res: TGLWE<N, K> = tgsw * tlwe;
+            let res: TGLWE = tgsw * tlwe;
 
             // let p_recovered = res.decrypt(&sk, beta);
             let p_recovered = res.decrypt(&sk);
             // downscaled by delta^-1
-            let res_recovered = TGLWE::<N, K>::decode::<T>(&p_recovered);
+            let res_recovered = TGLWE::decode(&param, &p_recovered);
 
             // assert_eq!(m1 * m2, m_recovered);
-            assert_eq!((m1.to_r() * m2.to_r()).to_rq::<T>(), res_recovered);
+            assert_eq!((m1.to_r() * m2.to_r()).to_rq(param.t), res_recovered);
         }
 
         Ok(())

--- a/tfhe/src/tggsw.rs
+++ b/tfhe/src/tggsw.rs
@@ -157,6 +157,7 @@ mod tests {
     #[test]
     fn test_external_product() -> Result<()> {
         let param = Param {
+            err_sigma: crate::ERR_SIGMA,
             ring: RingParam { q: u64::MAX, n: 64 },
             k: 4,
             t: 16, // plaintext modulus

--- a/tfhe/src/tglwe.rs
+++ b/tfhe/src/tglwe.rs
@@ -7,155 +7,193 @@ use std::array;
 use std::iter::Sum;
 use std::ops::{Add, AddAssign, Mul, Sub};
 
-use arith::{Ring, Rq, Tn, T64, TR};
-use gfhe::{glwe, GLWE};
+use arith::{Ring, RingParam, Rq, Tn, T64, TR};
+use gfhe::{glwe, glwe::Param, GLWE};
 
 use crate::tlev::TLev;
 use crate::{tlwe, tlwe::TLWE};
 
 // pub type SecretKey<const N: usize, const K: usize> = glwe::SecretKey<Tn<N>, K>;
 #[derive(Clone, Debug)]
-pub struct SecretKey<const N: usize, const K: usize>(pub glwe::SecretKey<Tn<N>, K>);
+pub struct SecretKey(pub glwe::SecretKey<Tn>);
 // pub struct SecretKey<const K: usize>(pub tlwe::SecretKey<K>);
 
-impl<const N: usize, const K: usize> SecretKey<N, K> {
-    pub fn to_tlwe<const KN: usize>(&self) -> tlwe::SecretKey<KN> {
-        let s: TR<Tn<N>, K> = self.0 .0.clone();
+impl SecretKey {
+    pub fn to_tlwe(&self, param: &Param) -> tlwe::SecretKey {
+        let s: TR<Tn> = self.0 .0.clone();
+        debug_assert_eq!(s.r.len(), param.k); // sanity check
 
-        let r: Vec<Vec<T64>> = s.0.iter().map(|s_i| s_i.coeffs()).collect();
+        let kn = param.k * param.ring.n;
+        let r: Vec<Vec<T64>> = s.r.iter().map(|s_i| s_i.coeffs()).collect();
         let r: Vec<T64> = r.into_iter().flatten().collect();
-        tlwe::SecretKey::<KN>(glwe::SecretKey::<T64, KN>(TR::<T64, KN>::new(r)))
+        debug_assert_eq!(r.len(), kn); // sanity check
+        tlwe::SecretKey(glwe::SecretKey::<T64>(TR::<T64>::new(kn, r)))
     }
 }
 
-pub type PublicKey<const N: usize, const K: usize> = glwe::PublicKey<Tn<N>, K>;
+pub type PublicKey = glwe::PublicKey<Tn>;
 
 #[derive(Clone, Debug)]
-pub struct TGLWE<const N: usize, const K: usize>(pub GLWE<Tn<N>, K>);
+pub struct TGLWE(pub GLWE<Tn>);
 
-impl<const N: usize, const K: usize> TGLWE<N, K> {
-    pub fn zero() -> Self {
-        Self(GLWE::<Tn<N>, K>::zero())
+impl TGLWE {
+    pub fn zero(k: usize, param: &RingParam) -> Self {
+        Self(GLWE::<Tn>::zero(k, param))
     }
-    pub fn from_plaintext(p: Tn<N>) -> Self {
-        Self(GLWE::<Tn<N>, K>::from_plaintext(p))
+    pub fn from_plaintext(k: usize, param: &RingParam, p: Tn) -> Self {
+        Self(GLWE::<Tn>::from_plaintext(k, param, p))
     }
 
-    pub fn new_key<const KN: usize>(
-        mut rng: impl Rng,
-    ) -> Result<(SecretKey<N, K>, PublicKey<N, K>)> {
+    pub fn new_key(mut rng: impl Rng, param: &Param) -> Result<(SecretKey, PublicKey)> {
         // assert_eq!(KN, K * N); // this is wip, while not being able to compute K*N
-        let (sk_tlwe, _) = TLWE::<KN>::new_key(&mut rng)?;
+        let (sk_tlwe, _) = TLWE::new_key(&mut rng, &param.lwe())?; //param.lwe() so that it uses K*N
+        debug_assert_eq!(sk_tlwe.0 .0.r.len(), param.lwe().k); // =KN (sanity check)
+
         // let sk = crate::tlwe::sk_to_tglwe::<N, K, KN>(sk_tlwe);
-        let sk = sk_tlwe.to_tglwe::<N, K>();
-        let pk: PublicKey<N, K> = GLWE::pk_from_sk(rng, sk.0.clone())?;
+        let sk = sk_tlwe.to_tglwe(param);
+        let pk: PublicKey = GLWE::pk_from_sk(rng, param, sk.0.clone())?;
         Ok((sk, pk))
     }
 
-    pub fn encode<const P: u64>(m: &Rq<P, N>) -> Tn<N> {
-        let delta = u64::MAX / P; // floored
+    pub fn encode(param: &Param, m: &Rq) -> Tn {
+        debug_assert_eq!(param.t, m.param.q); // plaintext modulus
+        let p = param.t;
+        let delta = u64::MAX / p; // floored
         let coeffs = m.coeffs();
-        Tn(array::from_fn(|i| T64(coeffs[i].0 * delta)))
+        // Tn(array::from_fn(|i| T64(coeffs[i].0 * delta)))
+        Tn {
+            param: param.ring,
+            coeffs: coeffs.iter().map(|c_i| T64(c_i.v * delta)).collect(),
+        }
     }
-    pub fn decode<const P: u64>(p: &Tn<N>) -> Rq<P, N> {
-        let p = p.mul_div_round(P, u64::MAX);
-        Rq::<P, N>::from_vec_u64(p.coeffs().iter().map(|c| c.0).collect())
+    pub fn decode(param: &Param, pt: &Tn) -> Rq {
+        let p = param.t;
+        let pt = pt.mul_div_round(p, u64::MAX);
+        Rq::from_vec_u64(&param.pt(), pt.coeffs().iter().map(|c| c.0).collect())
     }
 
     // encrypts with the given SecretKey (instead of PublicKey)
-    pub fn encrypt_s(rng: impl Rng, sk: &SecretKey<N, K>, p: &Tn<N>) -> Result<Self> {
-        let glwe = GLWE::encrypt_s(rng, &sk.0, p)?;
+    pub fn encrypt_s(rng: impl Rng, param: &Param, sk: &SecretKey, p: &Tn) -> Result<Self> {
+        let glwe = GLWE::encrypt_s(rng, param, &sk.0, p)?;
         Ok(Self(glwe))
     }
-    pub fn encrypt(rng: impl Rng, pk: &PublicKey<N, K>, p: &Tn<N>) -> Result<Self> {
-        let glwe = GLWE::encrypt(rng, &pk, p)?;
+    pub fn encrypt(rng: impl Rng, param: &Param, pk: &PublicKey, p: &Tn) -> Result<Self> {
+        let glwe = GLWE::encrypt(rng, param, &pk, p)?;
         Ok(Self(glwe))
     }
-    pub fn decrypt(&self, sk: &SecretKey<N, K>) -> Tn<N> {
+    pub fn decrypt(&self, sk: &SecretKey) -> Tn {
         self.0.decrypt(&sk.0)
     }
 
     /// Sample extraction / Coefficient extraction
-    pub fn sample_extraction<const KN: usize>(&self, h: usize) -> TLWE<KN> {
-        assert!(h < N);
+    pub fn sample_extraction(&self, param: &Param, h: usize) -> TLWE {
+        let n = param.ring.n;
+        assert!(h < n);
 
-        let a: TR<Tn<N>, K> = self.0 .0.clone();
+        let a: TR<Tn> = self.0 .0.clone();
         // set a_{n*i+j} = a_{i, h-j}     if j \in {0, h}
         //                 -a_{i, n+h-j}  if j \in {h+1, n-1}
         let new_a: Vec<T64> = a
             .iter()
             .flat_map(|a_i| {
                 let a_i = a_i.coeffs();
-                (0..N)
-                    .map(|j| if j <= h { a_i[h - j] } else { -a_i[N + h - j] })
+                (0..n)
+                    .map(|j| if j <= h { a_i[h - j] } else { -a_i[n + h - j] })
                     .collect::<Vec<T64>>()
             })
             .collect::<Vec<T64>>();
+        debug_assert_eq!(new_a.len(), param.k * param.ring.n); // sanity check
 
-        TLWE(GLWE(TR(new_a), self.0 .1.coeffs()[h]))
+        TLWE(GLWE(
+            TR {
+                // TODO use constructor `new`, which will check len with k
+                k: param.k * param.ring.n,
+                r: new_a,
+            },
+            self.0 .1.coeffs()[h],
+        ))
     }
     pub fn left_rotate(&self, h: usize) -> Self {
-        dbg!(&h);
-        let (a, b): (TR<Tn<N>, K>, Tn<N>) = (self.0 .0.clone(), self.0 .1);
+        let (a, b): (TR<Tn>, Tn) = (self.0 .0.clone(), self.0 .1.clone());
         Self(GLWE(a.left_rotate(h), b.left_rotate(h)))
     }
 }
 
-impl<const N: usize, const K: usize> Add<TGLWE<N, K>> for TGLWE<N, K> {
+impl Add<TGLWE> for TGLWE {
     type Output = Self;
     fn add(self, other: Self) -> Self {
+        debug_assert_eq!(self.0 .0.k, other.0 .0.k);
+        debug_assert_eq!(self.0 .1.param(), other.0 .1.param());
+
         Self(self.0 + other.0)
     }
 }
-impl<const N: usize, const K: usize> AddAssign for TGLWE<N, K> {
-    fn add_assign(&mut self, rhs: Self) {
-        self.0 += rhs.0
+impl AddAssign for TGLWE {
+    fn add_assign(&mut self, other: Self) {
+        debug_assert_eq!(self.0 .0.k, other.0 .0.k);
+        debug_assert_eq!(self.0 .1.param(), other.0 .1.param());
+
+        self.0 += other.0
     }
 }
-impl<const N: usize, const K: usize> Sum<TGLWE<N, K>> for TGLWE<N, K> {
-    fn sum<I>(iter: I) -> Self
+impl Sum<TGLWE> for TGLWE {
+    fn sum<I>(mut iter: I) -> Self
     where
         I: Iterator<Item = Self>,
     {
-        let mut acc = TGLWE::<N, K>::zero();
-        for e in iter {
-            acc += e;
-        }
-        acc
+        // let mut acc = TGLWE::<N, K>::zero();
+        // for e in iter {
+        //     acc += e;
+        // }
+        // acc
+        let first = iter.next().unwrap();
+        iter.fold(first, |acc, e| acc + e)
     }
 }
 
-impl<const N: usize, const K: usize> Sub<TGLWE<N, K>> for TGLWE<N, K> {
+impl Sub<TGLWE> for TGLWE {
     type Output = Self;
     fn sub(self, other: Self) -> Self {
+        debug_assert_eq!(self.0 .0.k, other.0 .0.k);
+        debug_assert_eq!(self.0 .1.param(), other.0 .1.param());
+
         Self(self.0 - other.0)
     }
 }
 
 // plaintext addition
-impl<const N: usize, const K: usize> Add<Tn<N>> for TGLWE<N, K> {
+impl Add<Tn> for TGLWE {
     type Output = Self;
-    fn add(self, plaintext: Tn<N>) -> Self {
-        let a: TR<Tn<N>, K> = self.0 .0;
-        let b: Tn<N> = self.0 .1 + plaintext;
+    fn add(self, plaintext: Tn) -> Self {
+        debug_assert_eq!(self.0 .1.param(), plaintext.param());
+
+        let a: TR<Tn> = self.0 .0;
+        let b: Tn = self.0 .1 + plaintext;
         Self(GLWE(a, b))
     }
 }
 // plaintext substraction
-impl<const N: usize, const K: usize> Sub<Tn<N>> for TGLWE<N, K> {
+impl Sub<Tn> for TGLWE {
     type Output = Self;
-    fn sub(self, plaintext: Tn<N>) -> Self {
-        let a: TR<Tn<N>, K> = self.0 .0;
-        let b: Tn<N> = self.0 .1 - plaintext;
+    fn sub(self, plaintext: Tn) -> Self {
+        debug_assert_eq!(self.0 .1.param(), plaintext.param());
+
+        let a: TR<Tn> = self.0 .0;
+        let b: Tn = self.0 .1 - plaintext;
         Self(GLWE(a, b))
     }
 }
 // plaintext multiplication
-impl<const N: usize, const K: usize> Mul<Tn<N>> for TGLWE<N, K> {
+impl Mul<Tn> for TGLWE {
     type Output = Self;
-    fn mul(self, plaintext: Tn<N>) -> Self {
-        let a: TR<Tn<N>, K> = TR(self.0 .0 .0.iter().map(|r_i| *r_i * plaintext).collect());
-        let b: Tn<N> = self.0 .1 * plaintext;
+    fn mul(self, plaintext: Tn) -> Self {
+        debug_assert_eq!(self.0 .1.param(), plaintext.param());
+
+        let a: TR<Tn> = TR {
+            k: self.0 .0.k,
+            r: self.0 .0.r.iter().map(|r_i| r_i * &plaintext).collect(),
+        };
+        let b: Tn = self.0 .1 * plaintext;
         Self(GLWE(a, b))
     }
 }
@@ -169,30 +207,31 @@ mod tests {
 
     #[test]
     fn test_encrypt_decrypt() -> Result<()> {
-        const T: u64 = 128; // msg space (msg modulus)
-        const N: usize = 64;
-        const K: usize = 16;
-        type S = TGLWE<N, K>;
+        let param = Param {
+            ring: RingParam { q: u64::MAX, n: 64 },
+            k: 16,
+            t: 128, // plaintext modulus
+        };
 
         let mut rng = rand::thread_rng();
-        let msg_dist = Uniform::new(0_u64, T);
+        let msg_dist = Uniform::new(0_u64, param.t);
 
         for _ in 0..200 {
-            let (sk, pk) = TGLWE::<N, K>::new_key::<{ K * N }>(&mut rng)?;
+            let (sk, pk) = TGLWE::new_key(&mut rng, &param)?;
 
-            let m = Rq::<T, N>::rand_u64(&mut rng, msg_dist)?;
-            let p: Tn<N> = S::encode::<T>(&m);
+            let m = Rq::rand_u64(&mut rng, msg_dist, &param.pt())?;
+            let p: Tn = TGLWE::encode(&param, &m);
 
-            let c = S::encrypt(&mut rng, &pk, &p)?;
+            let c = TGLWE::encrypt(&mut rng, &param, &pk, &p)?;
             let p_recovered = c.decrypt(&sk);
-            let m_recovered = S::decode::<T>(&p_recovered);
+            let m_recovered = TGLWE::decode(&param, &p_recovered);
 
             assert_eq!(m, m_recovered);
 
             // same but using encrypt_s (with sk instead of pk))
-            let c = S::encrypt_s(&mut rng, &sk, &p)?;
+            let c = TGLWE::encrypt_s(&mut rng, &param, &sk, &p)?;
             let p_recovered = c.decrypt(&sk);
-            let m_recovered = S::decode::<T>(&p_recovered);
+            let m_recovered = TGLWE::decode(&param, &p_recovered);
 
             assert_eq!(m, m_recovered);
         }
@@ -202,31 +241,32 @@ mod tests {
 
     #[test]
     fn test_addition() -> Result<()> {
-        const T: u64 = 128;
-        const N: usize = 64;
-        const K: usize = 16;
-        type S = TGLWE<N, K>;
+        let param = Param {
+            ring: RingParam { q: u64::MAX, n: 64 },
+            k: 16,
+            t: 128, // plaintext modulus
+        };
 
         let mut rng = rand::thread_rng();
-        let msg_dist = Uniform::new(0_u64, T);
+        let msg_dist = Uniform::new(0_u64, param.t);
 
         for _ in 0..200 {
-            let (sk, pk) = S::new_key::<{ K * N }>(&mut rng)?;
+            let (sk, pk) = TGLWE::new_key(&mut rng, &param)?;
 
-            let m1 = Rq::<T, N>::rand_u64(&mut rng, msg_dist)?;
-            let m2 = Rq::<T, N>::rand_u64(&mut rng, msg_dist)?;
-            let p1: Tn<N> = S::encode::<T>(&m1); // plaintext
-            let p2: Tn<N> = S::encode::<T>(&m2); // plaintext
+            let m1 = Rq::rand_u64(&mut rng, msg_dist, &param.pt())?;
+            let m2 = Rq::rand_u64(&mut rng, msg_dist, &param.pt())?;
+            let p1: Tn = TGLWE::encode(&param, &m1); // plaintext
+            let p2: Tn = TGLWE::encode(&param, &m2); // plaintext
 
-            let c1 = S::encrypt(&mut rng, &pk, &p1)?;
-            let c2 = S::encrypt(&mut rng, &pk, &p2)?;
+            let c1 = TGLWE::encrypt(&mut rng, &param, &pk, &p1)?;
+            let c2 = TGLWE::encrypt(&mut rng, &param, &pk, &p2)?;
 
             let c3 = c1 + c2;
 
             let p3_recovered = c3.decrypt(&sk);
-            let m3_recovered = S::decode::<T>(&p3_recovered);
+            let m3_recovered = TGLWE::decode(&param, &p3_recovered);
 
-            assert_eq!((m1 + m2).remodule::<T>(), m3_recovered.remodule::<T>());
+            assert_eq!((m1 + m2).remodule(param.t), m3_recovered.remodule(param.t));
         }
 
         Ok(())
@@ -234,28 +274,29 @@ mod tests {
 
     #[test]
     fn test_add_plaintext() -> Result<()> {
-        const T: u64 = 128;
-        const N: usize = 64;
-        const K: usize = 16;
-        type S = TGLWE<N, K>;
+        let param = Param {
+            ring: RingParam { q: u64::MAX, n: 64 },
+            k: 16,
+            t: 128, // plaintext modulus
+        };
 
         let mut rng = rand::thread_rng();
-        let msg_dist = Uniform::new(0_u64, T);
+        let msg_dist = Uniform::new(0_u64, param.t);
 
         for _ in 0..200 {
-            let (sk, pk) = S::new_key::<{ K * N }>(&mut rng)?;
+            let (sk, pk) = TGLWE::new_key(&mut rng, &param)?;
 
-            let m1 = Rq::<T, N>::rand_u64(&mut rng, msg_dist)?;
-            let m2 = Rq::<T, N>::rand_u64(&mut rng, msg_dist)?;
-            let p1: Tn<N> = S::encode::<T>(&m1); // plaintext
-            let p2: Tn<N> = S::encode::<T>(&m2); // plaintext
+            let m1 = Rq::rand_u64(&mut rng, msg_dist, &param.pt())?;
+            let m2 = Rq::rand_u64(&mut rng, msg_dist, &param.pt())?;
+            let p1: Tn = TGLWE::encode(&param, &m1); // plaintext
+            let p2: Tn = TGLWE::encode(&param, &m2); // plaintext
 
-            let c1 = S::encrypt(&mut rng, &pk, &p1)?;
+            let c1 = TGLWE::encrypt(&mut rng, &param, &pk, &p1)?;
 
             let c3 = c1 + p2;
 
             let p3_recovered = c3.decrypt(&sk);
-            let m3_recovered = S::decode::<T>(&p3_recovered);
+            let m3_recovered = TGLWE::decode(&param, &p3_recovered);
 
             assert_eq!(m1 + m2, m3_recovered);
         }
@@ -265,30 +306,34 @@ mod tests {
 
     #[test]
     fn test_mul_plaintext() -> Result<()> {
-        const T: u64 = 128;
-        const N: usize = 64;
-        const K: usize = 16;
-        type S = TGLWE<N, K>;
+        let param = Param {
+            ring: RingParam { q: u64::MAX, n: 64 },
+            k: 16,
+            t: 128, // plaintext modulus
+        };
 
         let mut rng = rand::thread_rng();
-        let msg_dist = Uniform::new(0_u64, T);
+        let msg_dist = Uniform::new(0_u64, param.t);
 
         for _ in 0..200 {
-            let (sk, pk) = S::new_key::<{ K * N }>(&mut rng)?;
+            let (sk, pk) = TGLWE::new_key(&mut rng, &param)?;
 
-            let m1 = Rq::<T, N>::rand_u64(&mut rng, msg_dist)?;
-            let m2 = Rq::<T, N>::rand_u64(&mut rng, msg_dist)?;
-            let p1: Tn<N> = S::encode::<T>(&m1);
+            let m1 = Rq::rand_u64(&mut rng, msg_dist, &param.pt())?;
+            let m2 = Rq::rand_u64(&mut rng, msg_dist, &param.pt())?;
+            let p1: Tn = TGLWE::encode(&param, &m1);
             // don't scale up p2, set it directly from m2
-            let p2: Tn<N> = Tn(array::from_fn(|i| T64(m2.coeffs()[i].0)));
+            let p2: Tn = Tn {
+                param: param.ring,
+                coeffs: m2.coeffs().iter().map(|c_i| T64(c_i.v)).collect(),
+            };
 
-            let c1 = S::encrypt(&mut rng, &pk, &p1)?;
+            let c1 = TGLWE::encrypt(&mut rng, &param, &pk, &p1)?;
 
             let c3 = c1 * p2;
 
-            let p3_recovered: Tn<N> = c3.decrypt(&sk);
-            let m3_recovered = S::decode::<T>(&p3_recovered);
-            assert_eq!((m1.to_r() * m2.to_r()).to_rq::<T>(), m3_recovered);
+            let p3_recovered: Tn = c3.decrypt(&sk);
+            let m3_recovered = TGLWE::decode(&param, &p3_recovered);
+            assert_eq!((m1.to_r() * m2.to_r()).to_rq(param.t), m3_recovered);
         }
 
         Ok(())
@@ -296,28 +341,29 @@ mod tests {
 
     #[test]
     fn test_sample_extraction() -> Result<()> {
-        const T: u64 = 128; // msg space (msg modulus)
-        const N: usize = 64;
-        const K: usize = 16;
-        const KN: usize = K * N;
+        let param = Param {
+            ring: RingParam { q: u64::MAX, n: 64 },
+            k: 16,
+            t: 128, // plaintext modulus
+        };
 
         let mut rng = rand::thread_rng();
-        let msg_dist = Uniform::new(0_u64, T);
+        let msg_dist = Uniform::new(0_u64, param.t);
 
         for _ in 0..20 {
-            let (sk, pk) = TGLWE::<N, K>::new_key::<KN>(&mut rng)?;
-            let sk_tlwe = sk.to_tlwe::<KN>();
+            let (sk, pk) = TGLWE::new_key(&mut rng, &param)?;
+            let sk_tlwe = sk.to_tlwe(&param);
 
-            let m = Rq::<T, N>::rand_u64(&mut rng, msg_dist)?;
-            let p: Tn<N> = TGLWE::<N, K>::encode::<T>(&m);
+            let m = Rq::rand_u64(&mut rng, msg_dist, &param.pt())?;
+            let p: Tn = TGLWE::encode(&param, &m);
 
-            let c = TGLWE::<N, K>::encrypt(&mut rng, &pk, &p)?;
+            let c = TGLWE::encrypt(&mut rng, &param, &pk, &p)?;
 
-            for h in 0..N {
-                let c_h: TLWE<KN> = c.sample_extraction(h);
+            for h in 0..param.ring.n {
+                let c_h: TLWE = c.sample_extraction(&param, h);
 
                 let p_recovered = c_h.decrypt(&sk_tlwe);
-                let m_recovered = TLWE::<KN>::decode::<T>(&p_recovered);
+                let m_recovered = TLWE::decode(&param, &p_recovered);
                 assert_eq!(m.coeffs()[h], m_recovered.coeffs()[0]);
             }
         }

--- a/tfhe/src/tgsw.rs
+++ b/tfhe/src/tgsw.rs
@@ -4,62 +4,63 @@ use rand::Rng;
 use std::array;
 use std::ops::{Add, Mul};
 
-use arith::{Ring, Rq, Tn, T64, TR};
+use arith::{Ring, RingParam, Rq, Tn, T64, TR};
 
 use crate::tlev::TLev;
 use crate::{
     tglwe::TGLWE,
     tlwe::{PublicKey, SecretKey, TLWE},
 };
-use gfhe::glwe::GLWE;
+use gfhe::glwe::{Param, GLWE};
 
 /// vector of length K+1 = [K], [1]
 #[derive(Clone, Debug)]
-pub struct TGSW<const K: usize>(pub(crate) Vec<TLev<K>>, TLev<K>);
+pub struct TGSW(pub(crate) Vec<TLev>, TLev);
 
-impl<const K: usize> TGSW<K> {
+impl TGSW {
     pub fn encrypt_s(
         mut rng: impl Rng,
+        param: &Param,
         beta: u32,
         l: u32,
-        sk: &SecretKey<K>,
+        sk: &SecretKey,
         m: &T64,
     ) -> Result<Self> {
-        let a: Vec<TLev<K>> = (0..K)
-            .map(|i| TLev::encrypt_s(&mut rng, beta, l, sk, &(-sk.0 .0 .0[i] * *m)))
+        let a: Vec<TLev> = (0..param.k)
+            .map(|i| TLev::encrypt_s(&mut rng, &param, beta, l, sk, &(-sk.0 .0.r[i] * *m)))
             .collect::<Result<Vec<_>>>()?;
-        let b: TLev<K> = TLev::encrypt_s(&mut rng, beta, l, sk, m)?;
+        let b: TLev = TLev::encrypt_s(&mut rng, &param, beta, l, sk, m)?;
         Ok(Self(a, b))
     }
 
-    pub fn decrypt(&self, sk: &SecretKey<K>, beta: u32) -> T64 {
+    pub fn decrypt(&self, sk: &SecretKey, beta: u32) -> T64 {
         self.1.decrypt(sk, beta)
     }
-    pub fn from_tlwe(_tlwe: TLWE<K>) -> Self {
+    pub fn from_tlwe(_tlwe: TLWE) -> Self {
         todo!()
     }
 
-    pub fn cmux(bit: Self, ct1: TLWE<K>, ct2: TLWE<K>) -> TLWE<K> {
+    pub fn cmux(bit: Self, ct1: TLWE, ct2: TLWE) -> TLWE {
         ct1.clone() + (bit * (ct2 - ct1))
     }
 }
 
 /// External product TGSW x TLWE
-impl<const K: usize> Mul<TLWE<K>> for TGSW<K> {
-    type Output = TLWE<K>;
+impl Mul<TLWE> for TGSW {
+    type Output = TLWE;
 
-    fn mul(self, tlwe: TLWE<K>) -> TLWE<K> {
+    fn mul(self, tlwe: TLWE) -> TLWE {
         let beta: u32 = 2;
         let l: u32 = 64; // TODO wip
 
         // since N=1, each tlwe element is a vector of length=1, decomposed into
         // l elements, and we have K of them
-        let tlwe_ab: Vec<T64> = [tlwe.0 .0 .0.clone(), vec![tlwe.0 .1]].concat();
+        let tlwe_ab: Vec<T64> = [tlwe.0 .0.r.clone(), vec![tlwe.0 .1]].concat();
 
-        let tgsw_ab: Vec<TLev<K>> = [self.0.clone(), vec![self.1]].concat();
+        let tgsw_ab: Vec<TLev> = [self.0.clone(), vec![self.1]].concat();
         assert_eq!(tgsw_ab.len(), tlwe_ab.len());
 
-        let r: TLWE<K> = zip_eq(tgsw_ab, tlwe_ab)
+        let r: TLWE = zip_eq(tgsw_ab, tlwe_ab)
             .map(|(tlev_i, tlwe_i)| tlev_i * tlwe_i.decompose(beta, l))
             .sum();
         r
@@ -75,25 +76,26 @@ mod tests {
 
     #[test]
     fn test_encrypt_decrypt() -> Result<()> {
-        const T: u64 = 2; // plaintext modulus
-        const K: usize = 16;
-        type S = TGSW<K>;
-
+        let param = Param {
+            ring: RingParam { q: u64::MAX, n: 1 },
+            k: 16,
+            t: 2, // plaintext modulus
+        };
         let beta: u32 = 2;
         let l: u32 = 16;
 
         let mut rng = rand::thread_rng();
-        let msg_dist = Uniform::new(0_u64, T);
+        let msg_dist = Uniform::new(0_u64, param.t);
 
         for _ in 0..50 {
-            let (sk, _) = TLWE::<K>::new_key(&mut rng)?;
+            let (sk, _) = TLWE::new_key(&mut rng, &param)?;
 
-            let m: Rq<T, 1> = Rq::rand_u64(&mut rng, msg_dist)?;
-            let p: T64 = TLev::<K>::encode::<T>(&m); // plaintext
+            let m: Rq = Rq::rand_u64(&mut rng, msg_dist, &param.pt())?;
+            let p: T64 = TLev::encode(&param, &m); // plaintext
 
-            let c = S::encrypt_s(&mut rng, beta, l, &sk, &p)?;
+            let c = TGSW::encrypt_s(&mut rng, &param, beta, l, &sk, &p)?;
             let p_recovered = c.decrypt(&sk, beta);
-            let m_recovered = TLev::<K>::decode::<T>(&p_recovered);
+            let m_recovered = TLev::decode(&param, &p_recovered);
 
             assert_eq!(m, m_recovered);
         }
@@ -103,36 +105,38 @@ mod tests {
 
     #[test]
     fn test_external_product() -> Result<()> {
-        const T: u64 = 2; // plaintext modulus
-        const K: usize = 32;
-
+        let param = Param {
+            ring: RingParam { q: u64::MAX, n: 1 },
+            k: 32,
+            t: 2, // plaintext modulus
+        };
         let beta: u32 = 2;
         let l: u32 = 64;
 
         let mut rng = rand::thread_rng();
-        let msg_dist = Uniform::new(0_u64, T);
+        let msg_dist = Uniform::new(0_u64, param.t);
 
         for _ in 0..50 {
-            let (sk, _) = TLWE::<K>::new_key(&mut rng)?;
+            let (sk, _) = TLWE::new_key(&mut rng, &param)?;
 
-            let m1: Rq<T, 1> = Rq::rand_u64(&mut rng, msg_dist)?;
-            let p1: T64 = TLev::<K>::encode::<T>(&m1);
+            let m1: Rq = Rq::rand_u64(&mut rng, msg_dist, &param.pt())?;
+            let p1: T64 = TLev::encode(&param, &m1);
 
-            let m2: Rq<T, 1> = Rq::rand_u64(&mut rng, msg_dist)?;
-            let p2: T64 = TLWE::<K>::encode::<T>(&m2); // scaled by delta
+            let m2: Rq = Rq::rand_u64(&mut rng, msg_dist, &param.pt())?;
+            let p2: T64 = TLWE::encode(&param, &m2); // scaled by delta
 
-            let tgsw = TGSW::<K>::encrypt_s(&mut rng, beta, l, &sk, &p1)?;
-            let tlwe = TLWE::<K>::encrypt_s(&mut rng, &sk, &p2)?;
+            let tgsw = TGSW::encrypt_s(&mut rng, &param, beta, l, &sk, &p1)?;
+            let tlwe = TLWE::encrypt_s(&mut rng, &param, &sk, &p2)?;
 
-            let res: TLWE<K> = tgsw * tlwe;
+            let res: TLWE = tgsw * tlwe;
 
             // let p_recovered = res.decrypt(&sk, beta);
             let p_recovered = res.decrypt(&sk);
             // downscaled by delta^-1
-            let res_recovered = TLWE::<K>::decode::<T>(&p_recovered);
+            let res_recovered = TLWE::decode(&param, &p_recovered);
 
             // assert_eq!(m1 * m2, m_recovered);
-            assert_eq!((m1.to_r() * m2.to_r()).to_rq::<T>(), res_recovered);
+            assert_eq!((m1.to_r() * m2.to_r()).to_rq(param.t), res_recovered);
         }
 
         Ok(())
@@ -140,35 +144,38 @@ mod tests {
 
     #[test]
     fn test_cmux() -> Result<()> {
-        const T: u64 = 2; // plaintext modulus
-        const K: usize = 32;
+        let param = Param {
+            ring: RingParam { q: u64::MAX, n: 1 },
+            k: 32,
+            t: 2, // plaintext modulus
+        };
 
         let beta: u32 = 2;
         let l: u32 = 64;
 
         let mut rng = rand::thread_rng();
-        let msg_dist = Uniform::new(0_u64, T);
+        let msg_dist = Uniform::new(0_u64, param.t);
 
         for _ in 0..50 {
-            let (sk, _) = TLWE::<K>::new_key(&mut rng)?;
+            let (sk, _) = TLWE::new_key(&mut rng, &param)?;
 
-            let m1: Rq<T, 1> = Rq::rand_u64(&mut rng, msg_dist)?;
-            let p1: T64 = TLWE::<K>::encode::<T>(&m1); // scaled by delta
+            let m1: Rq = Rq::rand_u64(&mut rng, msg_dist, &param.pt())?;
+            let p1: T64 = TLWE::encode(&param, &m1); // scaled by delta
 
-            let m2: Rq<T, 1> = Rq::rand_u64(&mut rng, msg_dist)?;
-            let p2: T64 = TLWE::<K>::encode::<T>(&m2); // scaled by delta
+            let m2: Rq = Rq::rand_u64(&mut rng, msg_dist, &param.pt())?;
+            let p2: T64 = TLWE::encode(&param, &m2); // scaled by delta
 
             for bit_raw in 0..2 {
-                let bit = TGSW::<K>::encrypt_s(&mut rng, beta, l, &sk, &T64(bit_raw))?;
+                let bit = TGSW::encrypt_s(&mut rng, &param, beta, l, &sk, &T64(bit_raw))?;
 
-                let c1 = TLWE::<K>::encrypt_s(&mut rng, &sk, &p1)?;
-                let c2 = TLWE::<K>::encrypt_s(&mut rng, &sk, &p2)?;
+                let c1 = TLWE::encrypt_s(&mut rng, &param, &sk, &p1)?;
+                let c2 = TLWE::encrypt_s(&mut rng, &param, &sk, &p2)?;
 
-                let res: TLWE<K> = TGSW::cmux(bit, c1, c2);
+                let res: TLWE = TGSW::cmux(bit, c1, c2);
 
                 let p_recovered = res.decrypt(&sk);
                 // downscaled by delta^-1
-                let res_recovered = TLWE::<K>::decode::<T>(&p_recovered);
+                let res_recovered = TLWE::decode(&param, &p_recovered);
 
                 if bit_raw == 0 {
                     assert_eq!(m1, res_recovered);

--- a/tfhe/src/tgsw.rs
+++ b/tfhe/src/tgsw.rs
@@ -1,17 +1,13 @@
 use anyhow::Result;
 use itertools::zip_eq;
 use rand::Rng;
-use std::array;
-use std::ops::{Add, Mul};
+use std::ops::Mul;
 
-use arith::{Ring, RingParam, Rq, Tn, T64, TR};
+use arith::{Ring, T64};
 
 use crate::tlev::TLev;
-use crate::{
-    tglwe::TGLWE,
-    tlwe::{PublicKey, SecretKey, TLWE},
-};
-use gfhe::glwe::{Param, GLWE};
+use crate::tlwe::{SecretKey, TLWE};
+use gfhe::glwe::Param;
 
 /// vector of length K+1 = [K], [1]
 #[derive(Clone, Debug)]
@@ -73,10 +69,12 @@ mod tests {
     use rand::distributions::Uniform;
 
     use super::*;
+    use arith::{RingParam, Rq};
 
     #[test]
     fn test_encrypt_decrypt() -> Result<()> {
         let param = Param {
+            err_sigma: crate::ERR_SIGMA,
             ring: RingParam { q: u64::MAX, n: 1 },
             k: 16,
             t: 2, // plaintext modulus
@@ -106,6 +104,7 @@ mod tests {
     #[test]
     fn test_external_product() -> Result<()> {
         let param = Param {
+            err_sigma: crate::ERR_SIGMA,
             ring: RingParam { q: u64::MAX, n: 1 },
             k: 32,
             t: 2, // plaintext modulus
@@ -130,7 +129,6 @@ mod tests {
 
             let res: TLWE = tgsw * tlwe;
 
-            // let p_recovered = res.decrypt(&sk, beta);
             let p_recovered = res.decrypt(&sk);
             // downscaled by delta^-1
             let res_recovered = TLWE::decode(&param, &p_recovered);
@@ -145,6 +143,7 @@ mod tests {
     #[test]
     fn test_cmux() -> Result<()> {
         let param = Param {
+            err_sigma: crate::ERR_SIGMA,
             ring: RingParam { q: u64::MAX, n: 1 },
             k: 32,
             t: 2, // plaintext modulus

--- a/tfhe/src/tlwe.rs
+++ b/tfhe/src/tlwe.rs
@@ -4,242 +4,276 @@ use rand::Rng;
 use std::iter::Sum;
 use std::ops::{Add, AddAssign, Mul, Sub};
 
-use arith::{Ring, Rq, Tn, Zq, T64, TR};
-use gfhe::{glwe, GLWE};
+use arith::{Ring, RingParam, Rq, Tn, Zq, T64, TR};
+use gfhe::{glwe, glwe::Param, GLWE};
 
 use crate::tggsw::TGGSW;
 use crate::tlev::TLev;
 use crate::{tglwe, tglwe::TGLWE};
 
-pub struct SecretKey<const K: usize>(pub glwe::SecretKey<T64, K>);
+pub struct SecretKey(pub glwe::SecretKey<T64>);
 
-impl<const KN: usize> SecretKey<KN> {
+impl SecretKey {
     /// from TFHE [2018-421] paper: A TLWE key k \in B^n, can be interpreted as a
     /// TRLWE key K \in B_N[X]^k having the same sequence of coefficients and
     /// vice-versa.
-    pub fn to_tglwe<const N: usize, const K: usize>(self) -> crate::tglwe::SecretKey<N, K> {
-        let s: TR<T64, KN> = self.0 .0;
+    pub fn to_tglwe(self, param: &Param) -> crate::tglwe::SecretKey {
+        let s: TR<T64> = self.0 .0; // of length K*N
+        assert_eq!(s.r.len(), param.k * param.ring.n); // sanity check
+
         // split into K vectors, and interpret each of them as a T_N[X]/(X^N+1)
         // polynomial
-        let r: Vec<Tn<N>> =
-            s.0.chunks(N)
-                .map(|v| Tn::<N>::from_vec(v.to_vec()))
+        let r: Vec<Tn> =
+            s.r.chunks(param.ring.n)
+                .map(|v| Tn::from_vec(&param.ring, v.to_vec()))
                 .collect();
-        crate::tglwe::SecretKey(glwe::SecretKey::<Tn<N>, K>(TR(r)))
+        crate::tglwe::SecretKey(glwe::SecretKey::<Tn>(TR { k: param.k, r }))
     }
 }
 
-pub type PublicKey<const K: usize> = glwe::PublicKey<T64, K>;
+pub type PublicKey = glwe::PublicKey<T64>;
 
 #[derive(Clone, Debug)]
-pub struct KSK<const K: usize>(Vec<TLev<K>>);
+pub struct KSK(Vec<TLev>);
 
 #[derive(Clone, Debug)]
-pub struct TLWE<const K: usize>(pub GLWE<T64, K>);
+pub struct TLWE(pub GLWE<T64>);
 
-impl<const K: usize> TLWE<K> {
-    pub fn zero() -> Self {
-        Self(GLWE::<T64, K>::zero())
+impl TLWE {
+    pub fn zero(k: usize, ring_param: &RingParam) -> Self {
+        Self(GLWE::<T64>::zero(k, ring_param))
     }
 
-    pub fn new_key(rng: impl Rng) -> Result<(SecretKey<K>, PublicKey<K>)> {
-        let (sk, pk): (glwe::SecretKey<T64, K>, glwe::PublicKey<T64, K>) = GLWE::new_key(rng)?;
+    pub fn new_key(rng: impl Rng, param: &Param) -> Result<(SecretKey, PublicKey)> {
+        let (sk, pk): (glwe::SecretKey<T64>, glwe::PublicKey<T64>) = GLWE::new_key(rng, param)?;
         Ok((SecretKey(sk), pk))
     }
 
-    pub fn encode<const P: u64>(m: &Rq<P, 1>) -> T64 {
-        let delta = u64::MAX / P; // floored
+    // TODO use param instead of p:u64
+    pub fn encode(param: &Param, m: &Rq) -> T64 {
+        assert_eq!(param.ring.n, 1);
+        debug_assert_eq!(param.t, m.param.q); // plaintext modulus
+                                              //
+        let delta = u64::MAX / param.t; // floored
         let coeffs = m.coeffs();
-        T64(coeffs[0].0 * delta)
+        T64(coeffs[0].v * delta)
     }
-    pub fn decode<const P: u64>(p: &T64) -> Rq<P, 1> {
-        let p = p.mul_div_round(P, u64::MAX);
-        Rq::<P, 1>::from_vec_u64(p.coeffs().iter().map(|c| c.0).collect())
+    pub fn decode(param: &Param, p: &T64) -> Rq {
+        let p = p.mul_div_round(param.t, u64::MAX);
+        Rq::from_vec_u64(&param.pt(), p.coeffs().iter().map(|c| c.0).collect())
     }
 
     // encrypts with the given SecretKey (instead of PublicKey)
-    pub fn encrypt_s(rng: impl Rng, sk: &SecretKey<K>, p: &T64) -> Result<Self> {
-        let glwe = GLWE::encrypt_s(rng, &sk.0, p)?;
+    pub fn encrypt_s(rng: impl Rng, param: &Param, sk: &SecretKey, p: &T64) -> Result<Self> {
+        let glwe = GLWE::encrypt_s(rng, param, &sk.0, p)?;
         Ok(Self(glwe))
     }
-    pub fn encrypt(rng: impl Rng, pk: &PublicKey<K>, p: &T64) -> Result<Self> {
-        let glwe = GLWE::encrypt(rng, &pk, p)?;
+    pub fn encrypt(rng: impl Rng, param: &Param, pk: &PublicKey, p: &T64) -> Result<Self> {
+        let glwe = GLWE::encrypt(rng, param, pk, p)?;
         Ok(Self(glwe))
     }
-    pub fn decrypt(&self, sk: &SecretKey<K>) -> T64 {
+    pub fn decrypt(&self, sk: &SecretKey) -> T64 {
         self.0.decrypt(&sk.0)
     }
 
     pub fn new_ksk(
         mut rng: impl Rng,
+        param: &Param,
         beta: u32,
         l: u32,
-        sk: &SecretKey<K>,
-        new_sk: &SecretKey<K>,
-    ) -> Result<KSK<K>> {
-        let r: Vec<TLev<K>> = (0..K)
+        sk: &SecretKey,
+        new_sk: &SecretKey,
+    ) -> Result<KSK> {
+        let r: Vec<TLev> = (0..param.k)
             .into_iter()
             .map(|i|
                 // treat sk_i as the msg being encrypted
-                TLev::<K>::encrypt_s(&mut rng, beta, l, &new_sk, &sk.0.0 .0[i]))
+                TLev::encrypt_s(&mut rng, param, beta, l, &new_sk, &sk.0.0 .r[i]))
             .collect::<Result<Vec<_>>>()?;
 
         Ok(KSK(r))
     }
-    pub fn key_switch(&self, beta: u32, l: u32, ksk: &KSK<K>) -> Self {
-        let (a, b): (TR<T64, K>, T64) = (self.0 .0.clone(), self.0 .1);
+    pub fn key_switch(&self, param: &Param, beta: u32, l: u32, ksk: &KSK) -> Self {
+        let (a, b): (TR<T64>, T64) = (self.0 .0.clone(), self.0 .1);
 
-        let lhs: TLWE<K> = TLWE(GLWE(TR::zero(), b));
+        let lhs: TLWE = TLWE(GLWE(TR::zero(param.k * param.ring.n, &param.ring), b));
 
         // K iterations, ksk.0 contains K times GLev
-        let rhs: TLWE<K> = zip_eq(a.0, ksk.0.clone())
+        let rhs: TLWE = zip_eq(a.r, ksk.0.clone())
             .map(|(a_i, ksk_i)| ksk_i * a_i.decompose(beta, l)) // dot_product
             .sum();
 
         lhs - rhs
     }
     // modulus switch from Q (2^64) to Q2 (in blind_rotation Q2=K*N)
-    pub fn mod_switch<const Q2: u64>(&self) -> Self {
-        let a: TR<T64, K> = self.0 .0.mod_switch::<Q2>();
-        let b: T64 = self.0 .1.mod_switch::<Q2>();
+    pub fn mod_switch(&self, q2: u64) -> Self {
+        let a: TR<T64> = self.0 .0.mod_switch(q2);
+        let b: T64 = self.0 .1.mod_switch(q2);
         Self(GLWE(a, b))
     }
 }
 // NOTE: the ugly const generics are temporary
-pub fn blind_rotation<const N: usize, const K: usize, const KN: usize, const KN2: u64>(
-    c: TLWE<KN>,
-    btk: BootstrappingKey<N, K, KN>,
-    table: TGLWE<N, K>,
-) -> TGLWE<N, K> {
-    let c_kn: TLWE<KN> = c.mod_switch::<KN2>();
-    let (a, b): (TR<T64, KN>, T64) = (c_kn.0 .0, c_kn.0 .1);
+pub fn blind_rotation(
+    param: &Param,
+    c: TLWE, // kn
+    btk: BootstrappingKey,
+    table: TGLWE, // n,k
+) -> TGLWE {
+    debug_assert_eq!(c.0 .0.k, param.k); // TODO or k*n?
+
+    // TODO replace `param.k*param.ring.n` by `param.kn()`
+    let c_kn: TLWE = c.mod_switch((param.k * param.ring.n) as u64);
+    let (a, b): (TR<T64>, T64) = (c_kn.0 .0, c_kn.0 .1);
     // two main parts: rotate by a known power of X, rotate by a secret
     // power of X (using the C gate)
 
     // table * X^-b, ie. left rotate
-    let v_xb: TGLWE<N, K> = table.left_rotate(b.0 as usize);
+    let v_xb: TGLWE = table.left_rotate(b.0 as usize);
 
     // rotate by a secret power of X using the cmux gate
-    let mut c_j: TGLWE<N, K> = v_xb.clone();
-    let _ = (1..K).map(|j| {
-        c_j = TGGSW::<N, K>::cmux(
+    let mut c_j: TGLWE = v_xb.clone();
+    let _ = (1..param.k).map(|j| {
+        c_j = TGGSW::cmux(
             btk.0[j].clone(),
             c_j.clone(),
-            c_j.clone().left_rotate(a.0[j].0 as usize),
+            c_j.clone().left_rotate(a.r[j].0 as usize),
         );
-        dbg!(&c_j);
+        // dbg!(&c_j);
     });
     c_j
 }
 
-pub fn bootstrapping<const N: usize, const K: usize, const KN: usize, const KN2: u64>(
-    btk: BootstrappingKey<N, K, KN>,
-    table: TGLWE<N, K>,
-    c: TLWE<KN>,
-) -> TLWE<KN> {
-    let rotated: TGLWE<N, K> = blind_rotation::<N, K, KN, KN2>(c, btk.clone(), table);
-    let c_h: TLWE<KN> = rotated.sample_extraction(0);
-    let r = c_h.key_switch(2, 64, &btk.1);
+pub fn bootstrapping(
+    param: &Param,
+    btk: BootstrappingKey,
+    table: TGLWE,
+    c: TLWE, // kn
+) -> TLWE {
+    // kn
+    let rotated: TGLWE = blind_rotation(param, c, btk.clone(), table);
+    let c_h: TLWE = rotated.sample_extraction(&param, 0);
+    let r = c_h.key_switch(param, 2, 64, &btk.1);
     r
 }
 
 #[derive(Clone, Debug)]
-pub struct BootstrappingKey<const N: usize, const K: usize, const KN: usize>(
-    pub Vec<TGGSW<N, K>>,
-    pub KSK<KN>,
+pub struct BootstrappingKey(
+    pub Vec<TGGSW>,
+    pub KSK, // kn
 );
-impl<const N: usize, const K: usize, const KN: usize> BootstrappingKey<N, K, KN> {
-    pub fn from_sk(mut rng: impl Rng, sk: &tglwe::SecretKey<N, K>) -> Result<Self> {
+impl BootstrappingKey {
+    pub fn from_sk(mut rng: impl Rng, param: &Param, sk: &tglwe::SecretKey) -> Result<Self> {
         let (beta, l) = (2u32, 64u32); // TMP
                                        //
-        let s: TR<Tn<N>, K> = sk.0 .0.clone();
-        let (sk2, _) = TLWE::<KN>::new_key(&mut rng)?; // TLWE<KN> compatible with TGLWE<N,K>
+        let s: TR<Tn> = sk.0 .0.clone();
+        let (sk2, _) = TLWE::new_key(&mut rng, &param.lwe())?; // TLWE<KN> compatible with TGLWE<N,K>
 
         // each btk_j = TGGSW_sk(s_i)
-        let btk: Vec<TGGSW<N, K>> = s
+        let btk: Vec<TGGSW> = s
             .iter()
-            .map(|s_i| TGGSW::<N, K>::encrypt_s(&mut rng, beta, l, sk, s_i))
+            .map(|s_i| TGGSW::encrypt_s(&mut rng, param, beta, l, sk, s_i))
             .collect::<Result<Vec<_>>>()?;
-        let ksk = TLWE::<KN>::new_ksk(&mut rng, beta, l, &sk.to_tlwe(), &sk2)?;
+
+        let ksk = TLWE::new_ksk(
+            &mut rng,
+            &param.lwe(),
+            beta,
+            l,
+            &sk.to_tlwe(&param.lwe()), // converted to length k*n
+            &sk2,                      // created with length k*n
+        )?;
+        debug_assert_eq!(ksk.0.len(), param.lwe().k);
+        debug_assert_eq!(ksk.0.len(), param.k * param.ring.n);
 
         Ok(Self(btk, ksk))
     }
 }
 
-pub fn compute_lookup_table<const T: u64, const K: usize, const N: usize>() -> TGLWE<N, K> {
+pub fn compute_lookup_table(param: &Param) -> TGLWE {
     // from 2021-1402:
     // v(x) = \sum_j^{N-1} [(p_j / 2N mod p)/p] X^j
 
     // matrix of coefficients with size K*N = delta x T
-    let delta: usize = N / T as usize;
-    let values: Vec<Zq<T>> = (0..T).map(|v| Zq::<T>::from_u64(v)).collect();
-    let coeffs: Vec<Zq<T>> = (0..T as usize)
+    let delta: usize = param.ring.n / param.t as usize;
+    let values: Vec<Zq> = (0..param.t).map(|v| Zq::from_u64(param.t, v)).collect();
+    let coeffs: Vec<Zq> = (0..param.t as usize)
         .flat_map(|i| vec![values[i]; delta])
         .collect();
-    let table = Rq::<T, N>::from_vec(coeffs);
+    let table = Rq::from_vec(&param.pt(), coeffs);
 
     // encode the table as plaintext
-    let v: Tn<N> = TGLWE::<N, K>::encode::<T>(&table);
+    let v: Tn = TGLWE::encode(param, &table);
 
     // encode the table as TGLWE ciphertext
-    let v: TGLWE<N, K> = TGLWE::<N, K>::from_plaintext(v);
+    let v: TGLWE = TGLWE::from_plaintext(param.k, &param.ring, v);
     v
 }
 
-impl<const K: usize> Add<TLWE<K>> for TLWE<K> {
+impl Add<TLWE> for TLWE {
     type Output = Self;
     fn add(self, other: Self) -> Self {
+        debug_assert_eq!(self.0 .0.k, other.0 .0.k);
+        debug_assert_eq!(self.0 .1.param(), other.0 .1.param());
         Self(self.0 + other.0)
     }
 }
-impl<const K: usize> AddAssign for TLWE<K> {
+impl AddAssign for TLWE {
     fn add_assign(&mut self, rhs: Self) {
+        debug_assert_eq!(self.0 .0.k, rhs.0 .0.k);
+        debug_assert_eq!(self.0 .1.param(), rhs.0 .1.param());
         self.0 += rhs.0
     }
 }
-impl<const K: usize> Sum<TLWE<K>> for TLWE<K> {
-    fn sum<I>(iter: I) -> Self
+impl Sum<TLWE> for TLWE {
+    fn sum<I>(mut iter: I) -> Self
     where
         I: Iterator<Item = Self>,
     {
-        let mut acc = TLWE::<K>::zero();
-        for e in iter {
-            acc += e;
-        }
-        acc
+        // let mut acc = TLWE::<K>::zero();
+        // for e in iter {
+        //     acc += e;
+        // }
+        // acc
+        let first = iter.next().unwrap();
+        iter.fold(first, |acc, e| acc + e)
     }
 }
 
-impl<const K: usize> Sub<TLWE<K>> for TLWE<K> {
+impl Sub<TLWE> for TLWE {
     type Output = Self;
     fn sub(self, other: Self) -> Self {
+        debug_assert_eq!(self.0 .0.k, other.0 .0.k);
+        debug_assert_eq!(self.0 .1.param(), other.0 .1.param());
         Self(self.0 - other.0)
     }
 }
 
 // plaintext addition
-impl<const K: usize> Add<T64> for TLWE<K> {
+impl Add<T64> for TLWE {
     type Output = Self;
     fn add(self, plaintext: T64) -> Self {
-        let a: TR<T64, K> = self.0 .0;
+        let a: TR<T64> = self.0 .0;
         let b: T64 = self.0 .1 + plaintext;
         Self(GLWE(a, b))
     }
 }
 // plaintext substraction
-impl<const K: usize> Sub<T64> for TLWE<K> {
+impl Sub<T64> for TLWE {
     type Output = Self;
     fn sub(self, plaintext: T64) -> Self {
-        let a: TR<T64, K> = self.0 .0;
+        let a: TR<T64> = self.0 .0;
         let b: T64 = self.0 .1 - plaintext;
         Self(GLWE(a, b))
     }
 }
 // plaintext multiplication
-impl<const K: usize> Mul<T64> for TLWE<K> {
+impl Mul<T64> for TLWE {
     type Output = Self;
     fn mul(self, plaintext: T64) -> Self {
-        let a: TR<T64, K> = TR(self.0 .0 .0.iter().map(|r_i| *r_i * plaintext).collect());
+        let a: TR<T64> = TR {
+            k: self.0 .0.k,
+            r: self.0 .0.r.iter().map(|r_i| *r_i * plaintext).collect(),
+        };
         let b: T64 = self.0 .1 * plaintext;
         Self(GLWE(a, b))
     }
@@ -255,29 +289,31 @@ mod tests {
 
     #[test]
     fn test_encrypt_decrypt() -> Result<()> {
-        const T: u64 = 128; // msg space (msg modulus)
-        const K: usize = 16;
-        type S = TLWE<K>;
+        let param = Param {
+            ring: RingParam { q: u64::MAX, n: 1 },
+            k: 16,
+            t: 128, // plaintext modulus
+        };
 
         let mut rng = rand::thread_rng();
-        let msg_dist = Uniform::new(0_u64, T);
+        let msg_dist = Uniform::new(0_u64, param.t);
 
         for _ in 0..200 {
-            let (sk, pk) = S::new_key(&mut rng)?;
+            let (sk, pk) = TLWE::new_key(&mut rng, &param)?;
 
-            let m = Rq::<T, 1>::rand_u64(&mut rng, msg_dist)?;
-            let p: T64 = S::encode::<T>(&m);
+            let m = Rq::rand_u64(&mut rng, msg_dist, &param.pt())?;
+            let p: T64 = TLWE::encode(&param, &m);
 
-            let c = S::encrypt(&mut rng, &pk, &p)?;
+            let c = TLWE::encrypt(&mut rng, &param, &pk, &p)?;
             let p_recovered = c.decrypt(&sk);
-            let m_recovered = S::decode::<T>(&p_recovered);
+            let m_recovered = TLWE::decode(&param, &p_recovered);
 
             assert_eq!(m, m_recovered);
 
             // same but using encrypt_s (with sk instead of pk))
-            let c = S::encrypt_s(&mut rng, &sk, &p)?;
+            let c = TLWE::encrypt_s(&mut rng, &param, &sk, &p)?;
             let p_recovered = c.decrypt(&sk);
-            let m_recovered = S::decode::<T>(&p_recovered);
+            let m_recovered = TLWE::decode(&param, &p_recovered);
 
             assert_eq!(m, m_recovered);
         }
@@ -287,30 +323,32 @@ mod tests {
 
     #[test]
     fn test_addition() -> Result<()> {
-        const T: u64 = 128;
-        const K: usize = 16;
-        type S = TLWE<K>;
+        let param = Param {
+            ring: RingParam { q: u64::MAX, n: 1 },
+            k: 16,
+            t: 128, // plaintext modulus
+        };
 
         let mut rng = rand::thread_rng();
-        let msg_dist = Uniform::new(0_u64, T);
+        let msg_dist = Uniform::new(0_u64, param.t);
 
         for _ in 0..200 {
-            let (sk, pk) = S::new_key(&mut rng)?;
+            let (sk, pk) = TLWE::new_key(&mut rng, &param)?;
 
-            let m1 = Rq::<T, 1>::rand_u64(&mut rng, msg_dist)?;
-            let m2 = Rq::<T, 1>::rand_u64(&mut rng, msg_dist)?;
-            let p1: T64 = S::encode::<T>(&m1); // plaintext
-            let p2: T64 = S::encode::<T>(&m2); // plaintext
+            let m1 = Rq::rand_u64(&mut rng, msg_dist, &param.pt())?;
+            let m2 = Rq::rand_u64(&mut rng, msg_dist, &param.pt())?;
+            let p1: T64 = TLWE::encode(&param, &m1); // plaintext
+            let p2: T64 = TLWE::encode(&param, &m2); // plaintext
 
-            let c1 = S::encrypt(&mut rng, &pk, &p1)?;
-            let c2 = S::encrypt(&mut rng, &pk, &p2)?;
+            let c1 = TLWE::encrypt(&mut rng, &param, &pk, &p1)?;
+            let c2 = TLWE::encrypt(&mut rng, &param, &pk, &p2)?;
 
             let c3 = c1 + c2;
 
             let p3_recovered = c3.decrypt(&sk);
-            let m3_recovered = S::decode::<T>(&p3_recovered);
+            let m3_recovered = TLWE::decode(&param, &p3_recovered);
 
-            assert_eq!((m1 + m2).remodule::<T>(), m3_recovered.remodule::<T>());
+            assert_eq!((m1 + m2).remodule(param.t), m3_recovered.remodule(param.t));
         }
 
         Ok(())
@@ -318,27 +356,29 @@ mod tests {
 
     #[test]
     fn test_add_plaintext() -> Result<()> {
-        const T: u64 = 128;
-        const K: usize = 16;
-        type S = TLWE<K>;
+        let param = Param {
+            ring: RingParam { q: u64::MAX, n: 1 },
+            k: 16,
+            t: 128, // plaintext modulus
+        };
 
         let mut rng = rand::thread_rng();
-        let msg_dist = Uniform::new(0_u64, T);
+        let msg_dist = Uniform::new(0_u64, param.t);
 
         for _ in 0..200 {
-            let (sk, pk) = S::new_key(&mut rng)?;
+            let (sk, pk) = TLWE::new_key(&mut rng, &param)?;
 
-            let m1 = Rq::<T, 1>::rand_u64(&mut rng, msg_dist)?;
-            let m2 = Rq::<T, 1>::rand_u64(&mut rng, msg_dist)?;
-            let p1: T64 = S::encode::<T>(&m1); // plaintext
-            let p2: T64 = S::encode::<T>(&m2); // plaintext
+            let m1 = Rq::rand_u64(&mut rng, msg_dist, &param.pt())?;
+            let m2 = Rq::rand_u64(&mut rng, msg_dist, &param.pt())?;
+            let p1: T64 = TLWE::encode(&param, &m1); // plaintext
+            let p2: T64 = TLWE::encode(&param, &m2); // plaintext
 
-            let c1 = S::encrypt(&mut rng, &pk, &p1)?;
+            let c1 = TLWE::encrypt(&mut rng, &param, &pk, &p1)?;
 
             let c3 = c1 + p2;
 
             let p3_recovered = c3.decrypt(&sk);
-            let m3_recovered = S::decode::<T>(&p3_recovered);
+            let m3_recovered = TLWE::decode(&param, &p3_recovered);
 
             assert_eq!(m1 + m2, m3_recovered);
         }
@@ -348,30 +388,32 @@ mod tests {
 
     #[test]
     fn test_mul_plaintext() -> Result<()> {
-        const T: u64 = 128;
-        const K: usize = 16;
-        type S = TLWE<K>;
+        let param = Param {
+            ring: RingParam { q: u64::MAX, n: 1 },
+            k: 16,
+            t: 128, // plaintext modulus
+        };
 
         let mut rng = rand::thread_rng();
-        let msg_dist = Uniform::new(0_u64, T);
+        let msg_dist = Uniform::new(0_u64, param.t);
 
         for _ in 0..200 {
-            let (sk, pk) = S::new_key(&mut rng)?;
+            let (sk, pk) = TLWE::new_key(&mut rng, &param)?;
 
-            let m1 = Rq::<T, 1>::rand_u64(&mut rng, msg_dist)?;
-            let m2 = Rq::<T, 1>::rand_u64(&mut rng, msg_dist)?;
-            let p1: T64 = S::encode::<T>(&m1);
+            let m1 = Rq::rand_u64(&mut rng, msg_dist, &param.pt())?;
+            let m2 = Rq::rand_u64(&mut rng, msg_dist, &param.pt())?;
+            let p1: T64 = TLWE::encode(&param, &m1);
             // don't scale up p2, set it directly from m2
             // let p2: T64 = Tn(array::from_fn(|i| T64(m2.coeffs()[i].0)));
-            let p2: T64 = T64(m2.coeffs()[0].0);
+            let p2: T64 = T64(m2.coeffs()[0].v);
 
-            let c1 = S::encrypt(&mut rng, &pk, &p1)?;
+            let c1 = TLWE::encrypt(&mut rng, &param, &pk, &p1)?;
 
             let c3 = c1 * p2;
 
             let p3_recovered: T64 = c3.decrypt(&sk);
-            let m3_recovered = S::decode::<T>(&p3_recovered);
-            assert_eq!((m1.to_r() * m2.to_r()).to_rq::<T>(), m3_recovered);
+            let m3_recovered = TLWE::decode(&param, &p3_recovered);
+            assert_eq!((m1.to_r() * m2.to_r()).to_rq(param.t), m3_recovered);
         }
 
         Ok(())
@@ -379,38 +421,40 @@ mod tests {
 
     #[test]
     fn test_key_switch() -> Result<()> {
-        const T: u64 = 128; // plaintext modulus
-        const K: usize = 16;
-        type S = TLWE<K>;
+        let param = Param {
+            ring: RingParam { q: u64::MAX, n: 1 },
+            k: 16,
+            t: 128, // plaintext modulus
+        };
 
         let beta: u32 = 2;
         let l: u32 = 64;
 
         let mut rng = rand::thread_rng();
 
-        let (sk, pk) = S::new_key(&mut rng)?;
-        let (sk2, _) = S::new_key(&mut rng)?;
+        let (sk, pk) = TLWE::new_key(&mut rng, &param)?;
+        let (sk2, _) = TLWE::new_key(&mut rng, &param)?;
         // ksk to switch from sk to sk2
-        let ksk = S::new_ksk(&mut rng, beta, l, &sk, &sk2)?;
+        let ksk = TLWE::new_ksk(&mut rng, &param, beta, l, &sk, &sk2)?;
 
-        let msg_dist = Uniform::new(0_u64, T);
-        let m = Rq::<T, 1>::rand_u64(&mut rng, msg_dist)?;
-        let p = S::encode::<T>(&m); // plaintext
-                                    //
-        let c = S::encrypt_s(&mut rng, &sk, &p)?;
+        let msg_dist = Uniform::new(0_u64, param.t);
+        let m = Rq::rand_u64(&mut rng, msg_dist, &param.pt())?;
+        let p = TLWE::encode(&param, &m); // plaintext
+                                          //
+        let c = TLWE::encrypt_s(&mut rng, &param, &sk, &p)?;
 
-        let c2 = c.key_switch(beta, l, &ksk);
+        let c2 = c.key_switch(&param, beta, l, &ksk);
 
         // decrypt with the 2nd secret key
         let p_recovered = c2.decrypt(&sk2);
-        let m_recovered = S::decode::<T>(&p_recovered);
-        assert_eq!(m.remodule::<T>(), m_recovered.remodule::<T>());
+        let m_recovered = TLWE::decode(&param, &p_recovered);
+        assert_eq!(m.remodule(param.t), m_recovered.remodule(param.t));
 
         // do the same but now encrypting with pk
-        let c = S::encrypt(&mut rng, &pk, &p)?;
-        let c2 = c.key_switch(beta, l, &ksk);
+        let c = TLWE::encrypt(&mut rng, &param, &pk, &p)?;
+        let c2 = c.key_switch(&param, beta, l, &ksk);
         let p_recovered = c2.decrypt(&sk2);
-        let m_recovered = S::decode::<T>(&p_recovered);
+        let m_recovered = TLWE::decode(&param, &p_recovered);
         assert_eq!(m, m_recovered);
 
         Ok(())
@@ -418,39 +462,44 @@ mod tests {
 
     #[test]
     fn test_bootstrapping() -> Result<()> {
-        const T: u64 = 128; // plaintext modulus
-        const K: usize = 1;
-        const N: usize = 1024;
-        const KN: usize = K * N;
+        let param = Param {
+            ring: RingParam {
+                q: u64::MAX,
+                n: 1024,
+            },
+            k: 1,
+            t: 128, // plaintext modulus
+        };
+        // const T: u64 = 128; // plaintext modulus
+        // const K: usize = 1;
+        // const N: usize = 1024;
+        // const KN: usize = K * N;
         let mut rng = rand::thread_rng();
 
         let start = Instant::now();
-        let table: TGLWE<N, K> = compute_lookup_table::<T, K, N>();
+        let table: TGLWE = compute_lookup_table(&param);
         println!("table took: {:?}", start.elapsed());
 
-        let (sk, _) = TGLWE::<N, K>::new_key::<KN>(&mut rng)?;
-        let sk_tlwe: SecretKey<KN> = sk.to_tlwe::<KN>();
+        let (sk, _) = TGLWE::new_key(&mut rng, &param)?;
+        let sk_tlwe: SecretKey = sk.to_tlwe(&param);
 
         let start = Instant::now();
-        let btk = BootstrappingKey::<N, K, KN>::from_sk(&mut rng, &sk)?;
+        let btk = BootstrappingKey::from_sk(&mut rng, &param, &sk)?;
         println!("btk took: {:?}", start.elapsed());
 
-        let msg_dist = Uniform::new(0_u64, T);
-        let m = Rq::<T, 1>::rand_u64(&mut rng, msg_dist)?;
-        dbg!(&m);
-        let p = TLWE::<K>::encode::<T>(&m); // plaintext
+        let msg_dist = Uniform::new(0_u64, param.t);
+        let m = Rq::rand_u64(&mut rng, msg_dist, &param.lwe().pt())?; // q=t, n=1
+        let p = TLWE::encode(&param.lwe(), &m); // plaintext
 
-        let c = TLWE::<KN>::encrypt_s(&mut rng, &sk_tlwe, &p)?;
+        let c = TLWE::encrypt_s(&mut rng, &param.lwe(), &sk_tlwe, &p)?;
 
         let start = Instant::now();
         // the ugly const generics are temporary
-        let bootstrapped: TLWE<KN> =
-            bootstrapping::<N, K, KN, { K as u64 * N as u64 }>(btk, table, c);
+        let bootstrapped: TLWE = bootstrapping(&param, btk, table, c);
         println!("bootstrapping took: {:?}", start.elapsed());
 
         let p_recovered: T64 = bootstrapped.decrypt(&sk_tlwe);
-        let m_recovered = TLWE::<KN>::decode::<T>(&p_recovered);
-        dbg!(&m_recovered);
+        let m_recovered = TLWE::decode(&param.lwe(), &p_recovered);
         assert_eq!(m_recovered, m);
 
         Ok(())

--- a/tfhe/src/tlwe.rs
+++ b/tfhe/src/tlwe.rs
@@ -61,6 +61,12 @@ impl TLWE {
         let p = p.mul_div_round(param.t, u64::MAX);
         Rq::from_vec_u64(&param.pt(), p.coeffs().iter().map(|c| c.0).collect())
     }
+    /// encodes the given message as a TLWE constant/public value, for using it
+    /// in ct-pt-multiplication.
+    pub fn new_const(param: &Param, m: &Rq) -> T64 {
+        debug_assert_eq!(param.t, m.param.q);
+        T64(m.coeffs()[0].v)
+    }
 
     // encrypts with the given SecretKey (instead of PublicKey)
     pub fn encrypt_s(rng: impl Rng, param: &Param, sk: &SecretKey, p: &T64) -> Result<Self> {
@@ -400,8 +406,7 @@ mod tests {
             let m1 = Rq::rand_u64(&mut rng, msg_dist, &param.pt())?;
             let m2 = Rq::rand_u64(&mut rng, msg_dist, &param.pt())?;
             let p1: T64 = TLWE::encode(&param, &m1);
-            // don't scale up p2, set it directly from m2
-            let p2: T64 = T64(m2.coeffs()[0].v);
+            let p2: T64 = TLWE::new_const(&param, &m2); // as constant/public value
 
             let c1 = TLWE::encrypt(&mut rng, &param, &pk, &p1)?;
 


### PR DESCRIPTION
Reason: using constant generics was great for allocating the arrays in the
stack, which is faster, but when started to use bigger parameter values,
in some cases it was overflowing the stack. This commit removes all the
constant generics in all of the crates, which in some cases slows
a bit the performance, but allows for bigger parameter values (on the
ones that affect lengths, like N and K).